### PR TITLE
fix(ci): update ossf/scorecard-action to v2.4.2

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@05b42c624433fc40171a86e4e50cbc6e6f92e5b4 # v2.4.1
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

Fix incorrect commit SHA for `ossf/scorecard-action`.

## Changes

- Updated `ossf/scorecard-action` from `05b42c624433fc40171a86e4e50cbc6e6f92e5b4` (v2.4.1) to `05b42c624433fc40578a4040d5cf5e36ddca8cde` (v2.4.2)

## Why

The previous pinned SHA was incorrect or outdated. This ensures we're using the correct v2.4.2 release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Scorecard workflow to pin ossf/scorecard-action to v2.4.2. This fixes an incorrect v2.4.1 pin so CI uses the intended release and produces reliable results.

<sup>Written for commit b065dae949a0db48ad8eff122a2acbddf73c9165. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

