### PR TITLE
chore: bump version to 0.2.1.dev1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "relace-mcp"
-version = "0.2.0"
+version = "0.2.1.dev1"
 description = "Unofficial Relace MCP Server - Fast code merging via Relace API"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/relace_mcp/__init__.py
+++ b/src/relace_mcp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0"
+__version__ = "0.2.1.dev1"
 
 from .server import build_server, main
 


### PR DESCRIPTION
Bump version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump package version to 0.2.1.dev1 in pyproject.toml and __version__ to start the 0.2.1 dev cycle and ensure consistent version reporting.

<sup>Written for commit 5213a907e7a1521d8125bb7f2c3ca3f681a36b05. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

