### PR TITLE
Revert "feat(platform): add cross-platform state directory support"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,30 +22,6 @@ MCP server for [Relace](https://www.relace.ai/) — AI-powered instant code merg
 - **Cloud Sync** — Upload local codebase to Relace Cloud for semantic search
 - **Cloud Search** — Semantic code search over cloud-synced repositories
 
-## Prerequisites
-
-| Tool | Required | Purpose | Installation |
-|------|----------|---------|--------------|
-| Python 3.11+ | ✅ | Runtime | [python.org](https://www.python.org/downloads/) |
-| uv | ✅ | Package manager | `pip install uv` or [astral.sh/uv](https://docs.astral.sh/uv/getting-started/installation/) |
-| Git | ⚠️ | `cloud_sync` | [git-scm.com](https://git-scm.com/downloads) |
-| ripgrep | ⚠️ | `fast_search` performance | [github.com/BurntSushi/ripgrep](https://github.com/BurntSushi/ripgrep#installation) |
-
-> ⚠️ = Optional but recommended for full functionality.
-
-### Platform Notes
-
-| Platform | Status | Notes |
-|----------|--------|-------|
-| Linux | ✅ Full | All features supported |
-| macOS | ✅ Full | All features supported |
-| Windows | ⚠️ Partial | `bash` tool disabled by default; requires Git for Windows |
-
-**State directory locations:**
-- Linux: `~/.local/state/relace/`
-- macOS: `~/Library/Application Support/relace/`
-- Windows: `%LOCALAPPDATA%\relace\`
-
 ## Quick Start
 
 1. Get your API key from [Relace Dashboard](https://app.relace.ai/settings/billing)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -110,7 +110,7 @@ Switch to OpenAI-compatible providers for `fast_search`:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `RELACE_SEARCH_ENABLED_TOOLS` | `view_file,view_directory,grep_search,glob` | Comma-separated allowlist. `report_back` is always enabled. Add `bash` to enable shell commands (Unix only). |
+| `RELACE_SEARCH_ENABLED_TOOLS` | — | Comma-separated allowlist (`view_file`, `view_directory`, `grep_search`, `glob`, `bash`). `report_back` is always enabled. |
 | `RELACE_SEARCH_PARALLEL_TOOL_CALLS` | `1` | Enable parallel tool calls for lower latency |
 
 ### OpenAI Structured Outputs Compatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "relace-mcp"
-version = "0.2.1a1"
+version = "0.2.1.dev1"
 description = "Unofficial Relace MCP Server - Fast code merging via Relace API"
 readme = "README.md"
 license = { text = "MIT" }
@@ -23,16 +23,7 @@ classifiers = [
     "Framework :: FastAPI",
     "Environment :: Plugins",
 ]
-dependencies = [
-    "fastmcp>=2.0.0",
-    "httpx>=0.28.0",
-    "python-dotenv>=1.0.0",
-    "charset-normalizer>=3.0.0",
-    "PyYAML>=6.0.0",
-    "openai>=1.0.0",
-    "tenacity>=8.0.0",
-    "platformdirs>=4.0.0",
-]
+dependencies = ["fastmcp>=2.0.0", "httpx>=0.28.0", "python-dotenv>=1.0.0", "charset-normalizer>=3.0.0", "PyYAML>=6.0.0", "openai>=1.0.0", "tenacity>=8.0.0"]
 
 [project.urls]
 Repository = "https://github.com/possible055/relace-mcp"
@@ -73,6 +64,7 @@ python_version = "3.11"
 testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+
 
 [tool.interrogate]
 ignore-init-method = true

--- a/src/relace_mcp/__init__.py
+++ b/src/relace_mcp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1a1"
+__version__ = "0.2.1.dev1"
 
 from .server import build_server, main
 

--- a/src/relace_mcp/config/settings.py
+++ b/src/relace_mcp/config/settings.py
@@ -3,8 +3,6 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from platformdirs import user_state_dir
-
 logger = logging.getLogger(__name__)
 
 # Fast Apply (OpenAI-compatible base URL; SDK appends /chat/completions automatically)
@@ -61,11 +59,7 @@ EXPERIMENTAL_LOGGING = os.getenv("RELACE_EXPERIMENTAL_LOGGING", "").lower() in (
 )
 
 # Logging
-# Cross-platform log directory:
-# - Linux: ~/.local/state/relace
-# - macOS: ~/Library/Application Support/relace
-# - Windows: %LOCALAPPDATA%\relace
-LOG_DIR = Path(user_state_dir("relace", ensure_exists=True))
+LOG_DIR = Path(os.environ.get("XDG_STATE_HOME", os.path.expanduser("~/.local/state"))) / "relace"
 LOG_PATH = LOG_DIR / "relace_apply.log"
 MAX_LOG_SIZE_BYTES = 10 * 1024 * 1024
 

--- a/src/relace_mcp/tools/repo/state.py
+++ b/src/relace_mcp/tools/repo/state.py
@@ -7,16 +7,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from platformdirs import user_state_dir
-
 logger = logging.getLogger(__name__)
 
 # XDG state directory for sync state files
-# Cross-platform state directory:
-# - Linux: ~/.local/state/relace/sync
-# - macOS: ~/Library/Application Support/relace/sync
-# - Windows: %LOCALAPPDATA%\relace\sync
-_STATE_DIR = Path(user_state_dir("relace", ensure_exists=True)) / "sync"
+_XDG_STATE_HOME = Path.home() / ".local" / "state" / "relace" / "sync"
 
 
 @dataclass
@@ -68,7 +62,7 @@ def _get_state_path(repo_name: str) -> Path:
     """Get the path to the sync state file for a repository."""
     # Sanitize repo name for filesystem
     safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in repo_name)
-    return _STATE_DIR / f"{safe_name}.json"
+    return _XDG_STATE_HOME / f"{safe_name}.json"
 
 
 def compute_file_hash(file_path: Path) -> str | None:

--- a/src/relace_mcp/tools/search/schemas/tool_schemas.py
+++ b/src/relace_mcp/tools/search/schemas/tool_schemas.py
@@ -276,8 +276,7 @@ def get_tool_schemas() -> list[dict[str, Any]]:
     Environment variables:
         - RELACE_SEARCH_ENABLED_TOOLS: Comma/space-separated allowlist, e.g.
           "view_file,view_directory,grep_search,glob,bash". `report_back` is always enabled.
-          If not set, defaults to: view_file, view_directory, grep_search, glob.
-          Note: `bash` is opt-in only (Unix-only, not enabled by default).
+          If not set, all tools are enabled by default.
         - RELACE_SEARCH_TOOL_STRICT: Set to 0/false to omit the non-standard `strict` field from tool schemas.
     """
     raw_allowlist = os.getenv("RELACE_SEARCH_ENABLED_TOOLS", "").strip()
@@ -285,7 +284,7 @@ def get_tool_schemas() -> list[dict[str, Any]]:
     if raw_allowlist:
         enabled = {t.strip().lower() for t in _split_tool_list(raw_allowlist)}
     else:
-        enabled = {"view_file", "view_directory", "grep_search", "glob", "report_back"}
+        enabled = {"view_file", "view_directory", "grep_search", "glob", "report_back", "bash"}
 
     # Always keep report_back so the harness can terminate deterministically.
     enabled.add("report_back")

--- a/tests/test_repo_sync.py
+++ b/tests/test_repo_sync.py
@@ -577,7 +577,7 @@ class TestSyncState:
     def test_save_and_load_sync_state(self, tmp_path: Path) -> None:
         """Should save and load sync state."""
         # Override XDG state dir for test
-        with patch("relace_mcp.tools.repo.state._STATE_DIR", tmp_path):
+        with patch("relace_mcp.tools.repo.state._XDG_STATE_HOME", tmp_path):
             state = SyncState(
                 repo_id="test-id",
                 repo_head="abc123",
@@ -594,7 +594,7 @@ class TestSyncState:
 
     def test_load_sync_state_missing(self, tmp_path: Path) -> None:
         """Should return None for missing state."""
-        with patch("relace_mcp.tools.repo.state._STATE_DIR", tmp_path):
+        with patch("relace_mcp.tools.repo.state._XDG_STATE_HOME", tmp_path):
             loaded = load_sync_state("nonexistent-project")
 
         assert loaded is None
@@ -678,7 +678,7 @@ class TestSyncStateCollisionDetection:
 
     def test_load_rejects_mismatched_repo_name(self, tmp_path: Path) -> None:
         """Should return None when stored repo_name doesn't match requested name."""
-        with patch("relace_mcp.tools.repo.state._STATE_DIR", tmp_path):
+        with patch("relace_mcp.tools.repo.state._XDG_STATE_HOME", tmp_path):
             # Save state for 'my.project'
             state = SyncState(
                 repo_id="project-a-id",
@@ -697,7 +697,7 @@ class TestSyncStateCollisionDetection:
 
     def test_load_accepts_matching_repo_name(self, tmp_path: Path) -> None:
         """Should accept state when repo_name matches."""
-        with patch("relace_mcp.tools.repo.state._STATE_DIR", tmp_path):
+        with patch("relace_mcp.tools.repo.state._XDG_STATE_HOME", tmp_path):
             state = SyncState(
                 repo_id="project-id",
                 repo_head="abc",
@@ -717,7 +717,7 @@ class TestSyncStateCollisionDetection:
         """Should accept old state files without repo_name for backward compat."""
         import json
 
-        with patch("relace_mcp.tools.repo.state._STATE_DIR", tmp_path):
+        with patch("relace_mcp.tools.repo.state._XDG_STATE_HOME", tmp_path):
             # Manually create old-format state file without repo_name
             state_file = tmp_path / "my_project.json"
             tmp_path.mkdir(parents=True, exist_ok=True)
@@ -742,7 +742,7 @@ class TestSyncStateCollisionDetection:
 
     def test_save_sets_repo_name_automatically(self, tmp_path: Path) -> None:
         """Should automatically set repo_name when saving."""
-        with patch("relace_mcp.tools.repo.state._STATE_DIR", tmp_path):
+        with patch("relace_mcp.tools.repo.state._XDG_STATE_HOME", tmp_path):
             state = SyncState(
                 repo_id="test-id",
                 repo_head="abc",

--- a/tests/test_search_harness.py
+++ b/tests/test_search_harness.py
@@ -380,12 +380,12 @@ class TestParallelToolCallsFix:
 class TestToolSchemas:
     """Test tool schema definitions."""
 
-    def test_has_five_default_tools(self) -> None:
-        """Should have exactly 5 default tools (bash is opt-in only)."""
-        assert len(TOOL_SCHEMAS) == 5
+    def test_has_six_tools(self) -> None:
+        """Should have exactly 6 tools (including bash + glob)."""
+        assert len(TOOL_SCHEMAS) == 6
 
     def test_tool_names(self) -> None:
-        """Should have correct default tool names (bash is opt-in only)."""
+        """Should have correct tool names."""
         names = {t["function"]["name"] for t in TOOL_SCHEMAS}
         assert names == {
             "view_file",
@@ -393,20 +393,12 @@ class TestToolSchemas:
             "grep_search",
             "glob",
             "report_back",
+            "bash",
         }
 
-    def test_bash_tool_opt_in(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """bash tool should only be enabled when explicitly added to allowlist."""
-        from relace_mcp.tools.search.schemas import get_tool_schemas
-
-        # Without explicit enablement, bash should not be present
-        default_names = {t["function"]["name"] for t in TOOL_SCHEMAS}
-        assert "bash" not in default_names
-
-        # With explicit enablement, bash should be present
-        monkeypatch.setenv("RELACE_SEARCH_ENABLED_TOOLS", "view_file,bash")
-        schemas = get_tool_schemas()
-        names = {t["function"]["name"] for t in schemas}
+    def test_bash_tool_exists(self) -> None:
+        """Should include bash tool for code exploration."""
+        names = {t["function"]["name"] for t in TOOL_SCHEMAS}
         assert "bash" in names
 
     def test_glob_tool_exists(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1448,6 +1448,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.407"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/1b/0aa08ee42948b61745ac5b5b5ccaec4669e8884b53d31c8ec20b2fcd6b6f/pyright-1.1.407.tar.gz", hash = "sha256:099674dba5c10489832d4a4b2d302636152a9a42d317986c38474c76fe562262", size = 4122872, upload-time = "2025-10-24T23:17:15.145Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/93/b69052907d032b00c40cb656d21438ec00b3a471733de137a3f65a49a0a0/pyright-1.1.407-py3-none-any.whl", hash = "sha256:6dd419f54fcc13f03b52285796d65e639786373f433e243f8b94cf93a7444d21", size = 5997008, upload-time = "2025-10-24T23:17:13.159Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1614,14 +1627,13 @@ wheels = [
 
 [[package]]
 name = "relace-mcp"
-version = "0.2.1.dev1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "openai" },
-    { name = "platformdirs" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "tenacity" },
@@ -1631,10 +1643,15 @@ dependencies = [
 dev = [
     { name = "dead" },
     { name = "interrogate" },
-    { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
 ]
 
 [package.metadata]
@@ -1644,10 +1661,9 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.1" },
     { name = "openai", specifier = ">=1.0.0" },
-    { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.1" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -1655,6 +1671,9 @@ requires-dist = [
     { name = "tenacity", specifier = ">=8.0.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "mypy", specifier = ">=1.19.1" }]
 
 [[package]]
 name = "requests"


### PR DESCRIPTION
Reverts possible055/relace-mcp#11

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts cross-platform state directory support and returns to XDG-style paths for logs and sync state. Removes platformdirs and updates tests/docs; default search tools now include bash.

- **Refactors**
  - Restore XDG paths: LOG_DIR at $XDG_STATE_HOME or ~/.local/state/relace; sync state at ~/.local/state/relace/sync.
  - Remove platformdirs and platform-specific docs; update tests; enable bash by default when RELACE_SEARCH_ENABLED_TOOLS is unset.

- **Migration**
  - If you ran the reverted build, move state/log files to ~/.local/state/relace (sync in ~/.local/state/relace/sync). Previous locations included macOS: ~/Library/Application Support/relace and Windows: %LOCALAPPDATA%\relace.

<sup>Written for commit de81d9f8616f7c1054a8f3a9887e0cfaff3ecb15. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

