### PR TITLE
docs: update prerequisites and platform support in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ MCP server for [Relace](https://www.relace.ai/) — AI-powered instant code merg
 
 ## Prerequisites
 
-- **Python 3.11+** and [uv](https://docs.astral.sh/uv/) or pip
-- **Git** (recommended, for `cloud_sync` to respect `.gitignore`)
+- [uv](https://docs.astral.sh/uv/) — Python package manager
+- [Git](https://git-scm.com/) — for `cloud_sync` to respect `.gitignore`
+- [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`) — recommended for `fast_search` (falls back to Python regex if unavailable)
 
 ### Platform Notes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,6 +15,22 @@
 
 [Relace](https://www.relace.ai/) 的 MCP 服务器 — AI 驱动的即时代码合并和智能代码库搜索。
 
+## 前置需求
+
+- [uv](https://docs.astral.sh/uv/) — Python 包管理器
+- [Git](https://git-scm.com/) — 用于让 `cloud_sync` 遵循 `.gitignore`
+- [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`) — 推荐用于 `fast_search`（未安装时会退化为 Python 正则匹配）
+
+### 平台支持
+
+| 平台 | 状态 | 备注 |
+|------|------|------|
+| Linux | ✅ 完全支持 | 主要开发平台 |
+| macOS | ✅ 完全支持 | 所有功能可用 |
+| Windows | ⚠️ 部分支持 | `bash` 工具不可用；使用 WSL 以获得完整功能 |
+
+> **Windows 用户：** `bash` 工具需要 Unix shell。安装 [WSL](https://learn.microsoft.com/windows/wsl/install) 以获得完整功能，或使用其他探索工具（`view_file`、`grep_search`、`glob`）。
+
 ## 功能特性
 
 - **快速应用** — 通过 Relace API 以 10,000+ tokens/秒的速度应用代码编辑
@@ -87,7 +103,7 @@
 
 搜索代码库并返回相关文件和行范围。
 
-**参数：** `query` — 自然语言搜索查询
+**参数：** `query` —— 自然语言搜索查询
 
 **响应示例：**
 
@@ -103,7 +119,7 @@
 ```
 
 **参数：**
-- `query` — 自然语言搜索查询
+- `query` —— 自然语言搜索查询
 
 ### `cloud_sync`
 


### PR DESCRIPTION
## Summary

Updates the Prerequisites section in both README files to accurately reflect the actual dependencies.

## Changes

### Prerequisites Section
- **Removed**: `Python 3.11+` and `pip` (not actual prerequisites - uv handles Python)
- **Added**: `ripgrep` (`rg`) with correct description
- **Clarified**: ripgrep is **recommended**, not required - falls back to Python regex if unavailable

### Chinese README (README.zh-CN.md)
- Added missing Prerequisites section (前置需求)
- Added Platform Notes section (平台支持)
- Synchronized structure with English README

## Technical Details

The `fast_search` tool's `grep_search` handler implements graceful degradation:

```python
def grep_search_handler(params: GrepSearchParams) -> str:
    try:
        return _try_ripgrep(params)
    except (FileNotFoundError, subprocess.TimeoutExpired):
        return _grep_search_python_fallback(params)  # Pure Python fallback
```

This ensures the tool works without ripgrep installed, using Python's `re` module as fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update both READMEs to reflect actual prerequisites and add platform support. Remove Python 3.11+/pip, list uv as the package manager, recommend ripgrep for fast_search with Python regex fallback, add missing 前置需求/平台支持 to README.zh-CN, and note Windows partial support with WSL recommended.

<sup>Written for commit 717054361d57706f15cf94dfc83912b849d2ae99. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

