### PR TITLE
refactor(indexing)!: enforce single active index mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Single active index mode** — The server now exposes exactly one active indexing backend at a time: `relace`, `codanna`, `chunkhound`, or `none`.
+- **`index_status` contract** — Now reports only the active backend and is strictly read-only; it no longer schedules background refreshes.
+- **Cloud tool visibility** — `cloud_sync`, `cloud_search`, `cloud_list`, `cloud_clear`, and `relace://cloud/status` are exposed only when `MCP_RETRIEVAL_BACKEND=relace`.
+
+### Removed
+
+- **`MCP_RETRIEVAL_BACKEND=auto`** — Auto backend selection is no longer supported. Pick an explicit backend.
+- **`RELACE_CLOUD_TOOLS`** — Legacy cloud-tool compatibility flag removed. Use `MCP_RETRIEVAL_BACKEND=relace`.
+
 ## [0.2.5] - TBD
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ MCP server providing AI-powered code editing and intelligent codebase exploratio
 
 **Prerequisites:** [uv](https://docs.astral.sh/uv/), [git](https://git-scm.com/), [ripgrep](https://github.com/BurntSushi/ripgrep) (recommended)
 
-Using Relace (default) or `RELACE_CLOUD_TOOLS=1`: get your API key from [Relace Dashboard](https://app.relace.ai/settings/billing), then add to your MCP client:
+Using the `relace` backend (default): get your API key from [Relace Dashboard](https://app.relace.ai/settings/billing), then add to your MCP client:
 
 <details>
 <summary><strong>Cursor</strong></summary>
@@ -139,9 +139,8 @@ MCP_BASE_DIR = "/absolute/path/to/your/project"
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `RELACE_API_KEY` | ✅* | API key from [Relace Dashboard](https://app.relace.ai/settings/billing); required for Relace providers and cloud tools |
-| `RELACE_CLOUD_TOOLS` | ❌ | Set to `1` to enable cloud tools |
 | `MCP_SEARCH_RETRIEVAL` | ❌ | Set to `1` to register the `agentic_retrieval` tool |
-| `MCP_RETRIEVAL_BACKEND` | ❌ | Semantic retrieval backend: `relace` (default), `codanna`, `chunkhound`, `auto`, or `none` |
+| `MCP_RETRIEVAL_BACKEND` | ❌ | Semantic retrieval backend: `relace` (default), `codanna`, `chunkhound`, or `none` |
 | `MCP_RETRIEVAL_HINT_POLICY` | ❌ | Retrieval hint policy: `prefer-stale` (default) or `strict` |
 | `MCP_BACKGROUND_INDEX_MONITOR` | ❌ | Opt-in periodic refresh monitor for local indexes; requires a pinned `MCP_BASE_DIR` and a local backend |
 | `MCP_BACKGROUND_INDEX_INTERVAL_SECONDS` | ❌ | Periodic local index monitor interval in seconds (default: `300`) |
@@ -153,13 +152,13 @@ MCP_BASE_DIR = "/absolute/path/to/your/project"
 | `MCP_LOGGING` | ❌ | File logging: `off` (default), `safe`, `full` |
 | `MCP_DOTENV_PATH` | ❌ | Path to `.env` file for centralized config |
 
-`*` Optional if **both**: (1) `APPLY_PROVIDER` and `SEARCH_PROVIDER` are non-Relace providers, and (2) `RELACE_CLOUD_TOOLS=false`.
+`*` Optional if **both**: (1) `APPLY_PROVIDER` and `SEARCH_PROVIDER` are non-Relace providers, and (2) `MCP_RETRIEVAL_BACKEND` is `codanna`, `chunkhound`, or `none`.
 
 For `.env` usage, encoding settings, custom LLM providers, and more, see [docs/advanced.md](docs/advanced.md).
 
 ## Tools
 
-Always available: `fast_apply`, `agentic_search`. `agentic_retrieval` requires `MCP_SEARCH_RETRIEVAL=1`. Cloud tools require `RELACE_CLOUD_TOOLS=1`. `index_status` is available when cloud tools are enabled or a local index CLI (`codanna` / `chunkhound`) is available in `PATH`.
+Always available: `fast_apply`, `agentic_search`. `agentic_retrieval` requires `MCP_SEARCH_RETRIEVAL=1`. Cloud tools are available only when `MCP_RETRIEVAL_BACKEND=relace`. `index_status` is available for `relace`, `codanna`, and `chunkhound`, and hidden when `MCP_RETRIEVAL_BACKEND=none`.
 
 Use MCP-native discovery surfaces: `list_tools()` for tools and `list_resources()` for resources.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,7 +34,7 @@
 
 **前置需求：** [uv](https://docs.astral.sh/uv/)、[git](https://git-scm.com/)、[ripgrep](https://github.com/BurntSushi/ripgrep)（推荐）
 
-使用 Relace（默认）或 `RELACE_CLOUD_TOOLS=1`：从 [Relace Dashboard](https://app.relace.ai/settings/billing) 获取 API 密钥，然后添加到你的 MCP 客户端：
+使用 `relace` backend（默认）：从 [Relace Dashboard](https://app.relace.ai/settings/billing) 获取 API 密钥，然后添加到你的 MCP 客户端：
 
 <details>
 <summary><strong>Cursor</strong></summary>
@@ -139,9 +139,8 @@ MCP_BASE_DIR = "/absolute/path/to/your/project"
 | 变量 | 必需 | 说明 |
 |------|------|------|
 | `RELACE_API_KEY` | ✅* | 来自 [Relace Dashboard](https://app.relace.ai/settings/billing) 的 API 密钥；在使用 Relace provider 或云端工具时必需 |
-| `RELACE_CLOUD_TOOLS` | ❌ | 设为 `1` 启用云端工具 |
 | `MCP_SEARCH_RETRIEVAL` | ❌ | 设为 `1` 注册 `agentic_retrieval` 工具 |
-| `MCP_RETRIEVAL_BACKEND` | ❌ | semantic retrieval backend：`relace`（默认）、`codanna`、`chunkhound`、`auto` 或 `none` |
+| `MCP_RETRIEVAL_BACKEND` | ❌ | semantic retrieval backend：`relace`（默认）、`codanna`、`chunkhound` 或 `none` |
 | `MCP_RETRIEVAL_HINT_POLICY` | ❌ | retrieval hint policy：`prefer-stale`（默认）或 `strict` |
 | `MCP_BACKGROUND_INDEX_MONITOR` | ❌ | 为 local index 启用可选的周期 refresh monitor；要求固定的 `MCP_BASE_DIR` 与 local backend |
 | `MCP_BACKGROUND_INDEX_INTERVAL_SECONDS` | ❌ | 周期 local index monitor 的检查间隔（秒，默认 `300`） |
@@ -153,13 +152,13 @@ MCP_BASE_DIR = "/absolute/path/to/your/project"
 | `MCP_LOGGING` | ❌ | 文件日志：`off`（默认）、`safe`、`full` |
 | `MCP_DOTENV_PATH` | ❌ | `.env` 文件路径，用于集中配置 |
 
-`*` 仅当**同时满足**：(1) `APPLY_PROVIDER` 与 `SEARCH_PROVIDER` 均为非 Relace 提供商，且 (2) `RELACE_CLOUD_TOOLS=false` 时可省略。
+`*` 仅当**同时满足**：(1) `APPLY_PROVIDER` 与 `SEARCH_PROVIDER` 均为非 Relace 提供商，且 (2) `MCP_RETRIEVAL_BACKEND` 为 `codanna`、`chunkhound` 或 `none` 时可省略。
 
 `.env` 使用方法、编码设置、自定义 LLM 等进阶设置，请参见 [docs/advanced.zh-CN.md](docs/advanced.zh-CN.md)。
 
 ## 工具
 
-始终可用的工具有：`fast_apply`、`agentic_search`。`agentic_retrieval` 需设置 `MCP_SEARCH_RETRIEVAL=1`。云端工具需设置 `RELACE_CLOUD_TOOLS=1`。`index_status` 会在启用云端工具，或 `PATH` 中可找到本地 index CLI（`codanna` / `chunkhound`）时可用。
+始终可用的工具有：`fast_apply`、`agentic_search`。`agentic_retrieval` 需设置 `MCP_SEARCH_RETRIEVAL=1`。云端工具只会在 `MCP_RETRIEVAL_BACKEND=relace` 时可用。`index_status` 会在 `relace`、`codanna`、`chunkhound` backend 下可用，在 `MCP_RETRIEVAL_BACKEND=none` 时隐藏。
 
 可用性发现请使用 MCP 原生接口：tools 用 `list_tools()`，resources 用 `list_resources()`。
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -29,14 +29,13 @@ All environment variables can be set in your shell or in the `env` section of yo
 | `RELACE_DEFAULT_ENCODING` | — | Force default encoding for project files (e.g., `gbk`, `big5`) |
 | `MCP_LOGGING` | `off` | File logging: `off`, `safe` (with redaction), `full` (no redaction) |
 | `MCP_LOG_LEVEL` | `WARNING` | Stderr log verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `RELACE_CLOUD_TOOLS` | `0` | Set to `1` to enable cloud tools (cloud_sync, cloud_search, etc.) |
 | `MCP_SEARCH_RETRIEVAL` | `0` | Set to `1` to register the `agentic_retrieval` tool |
-| `MCP_RETRIEVAL_BACKEND` | `relace` | Semantic retrieval backend: `relace`, `codanna`, `chunkhound`, `auto`, `none` |
+| `MCP_RETRIEVAL_BACKEND` | `relace` | Semantic retrieval backend: `relace`, `codanna`, `chunkhound`, `none` |
 | `MCP_BACKGROUND_INDEX_MONITOR` | `0` | Opt-in periodic refresh monitor for local indexes; requires `MCP_BASE_DIR` and a local backend |
 | `MCP_BACKGROUND_INDEX_INTERVAL_SECONDS` | `300` | Interval between periodic local index checks |
 | `MCP_BACKGROUND_INDEX_INITIAL_DELAY_SECONDS` | `30` | Startup delay before the first periodic local index check |
 
-> **Note:** `RELACE_API_KEY` can be omitted if **both**: (1) using non-Relace providers for `APPLY_PROVIDER` and `SEARCH_PROVIDER`, and (2) `RELACE_CLOUD_TOOLS=false`. Otherwise it is required.
+> **Note:** `RELACE_API_KEY` can be omitted if **both**: (1) using non-Relace providers for `APPLY_PROVIDER` and `SEARCH_PROVIDER`, and (2) `MCP_RETRIEVAL_BACKEND` is `codanna`, `chunkhound`, or `none`. Otherwise it is required.
 
 > **Warning:** `MCP_LOGGING=full` writes **all** content to disk unredacted, including source code snippets, LLM instructions, tool arguments, search queries, command output, and error messages with stack traces. Use `full` only for debugging in trusted environments. `safe` mode replaces sensitive field values with `[REDACTED len=<N> sha256=<HEX12>]` placeholders — the sha256 prefix allows correlating redacted values across events without revealing content.
 
@@ -150,7 +149,7 @@ When git HEAD changes since last sync (e.g., branch switch, rebase), Safe Full m
 
 ## Local Retrieval Backends
 
-`agentic_retrieval` uses semantic search to pre-rank files before the agentic pass, then verifies those hints against live code. By default it uses the Relace cloud index (`relace` backend, requires `RELACE_CLOUD_TOOLS=1` and a synced repo). To run without cloud dependency, use a local backend.
+`agentic_retrieval` uses semantic search to pre-rank files before the agentic pass, then verifies those hints against live code. By default it uses the Relace cloud index (`relace` backend, requires `RELACE_API_KEY` and a synced repo). To run without cloud dependency, use a local backend.
 
 ### Hint Freshness Policy
 
@@ -193,17 +192,6 @@ MCP_RETRIEVAL_BACKEND=chunkhound
 
 If the index is missing or stale, the server may continue without hints while scheduling a background refresh. With `MCP_RETRIEVAL_HINT_POLICY=prefer-stale`, retrieval can still use stale ChunkHound hints; `strict` skips them. Refer to the [ChunkHound project](https://pypi.org/project/chunkhound/) for configuration and embedding model setup.
 
-### Auto Mode
-
-```bash
-MCP_SEARCH_RETRIEVAL=1
-MCP_RETRIEVAL_BACKEND=auto
-```
-
-The server picks the first available backend per session: `codanna` → `chunkhound` → `relace` (cloud fallback).
-
-When the selected local backend is stale or missing, retrieval can schedule a background refresh. The query path does not block on rebuild completion.
-
 ### Background Index Monitor
 
 ```bash
@@ -213,17 +201,17 @@ MCP_BASE_DIR=/absolute/path/to/repo
 MCP_BACKGROUND_INDEX_MONITOR=1
 ```
 
-`index_status` is exposed only when `RELACE_CLOUD_TOOLS=1` or a local index CLI (`codanna` / `chunkhound`) is discoverable in `PATH`.
+`index_status` is exposed only when `MCP_RETRIEVAL_BACKEND` is `relace`, `codanna`, or `chunkhound`.
 
 When enabled, the server runs a periodic local-only freshness check and triggers a background refresh for the selected local backend when needed.
 
 - It is `off` by default.
 - It only starts when `MCP_BASE_DIR` is pinned to a single repository.
-- It only monitors the active local backend (`codanna`, `chunkhound`, or the local choice from `auto`).
+- It only monitors the active local backend (`codanna` or `chunkhound`).
 - It uses a host-local file lock to avoid duplicate index CLI runs when multiple local MCP processes happen to point at the same repo.
 - It is intended for single-process deployments. For multi-worker or multi-pod HTTP deployments, disable it and use backend-native watch/daemon flows or an external scheduler.
 
-`index_status` includes a `background_monitor` summary so you can verify whether the monitor is active and why it may be disabled.
+`index_status` includes a compact `background_monitor` summary so you can verify the monitor state and, when needed, the blocking reason.
 
 ---
 
@@ -293,13 +281,13 @@ Trace logs are also JSONL. Each line is one event.
 | `tool_call` | Tool call with timing |
 | `search_complete` | Search completed |
 | `search_error` | Search failed |
-| `index_status` | Indexing backends summary (relace/codanna/chunkhound) |
+| `index_status` | Active indexing backend summary |
 | `index_status_error` | Indexing status error (e.g., base_dir resolution failure) |
 | `backend_index_start` | Codanna/ChunkHound indexing started |
 | `backend_index_complete` | Codanna/ChunkHound indexing completed |
 | `backend_index_error` | Codanna/ChunkHound indexing failed |
 | `backend_disabled` | Backend disabled for session (e.g., CLI missing) |
-| `retrieval_backend_selected` | Retrieval backend selection (including auto) |
+| `retrieval_backend_selected` | Retrieval backend selection |
 | `retrieval_hints_skipped` | Retrieval hints skipped because policy/backend freshness did not allow them |
 | `retrieval_hints_complete` | Retrieval hints completed |
 | `retrieval_hints_error` | Retrieval hints failed (fallback continues) |

--- a/docs/advanced.zh-CN.md
+++ b/docs/advanced.zh-CN.md
@@ -29,14 +29,13 @@
 | `RELACE_DEFAULT_ENCODING` | — | 强制项目文件编码（如 `gbk`、`big5`） |
 | `MCP_LOGGING` | `off` | 文件日志：`off`、`safe`（启用并遮蔽）、`full`（启用不遮蔽） |
 | `MCP_LOG_LEVEL` | `WARNING` | stderr 日志级别：`DEBUG`、`INFO`、`WARNING`、`ERROR` |
-| `RELACE_CLOUD_TOOLS` | `0` | 设为 `1` 启用云工具（cloud_sync、cloud_search 等） |
 | `MCP_SEARCH_RETRIEVAL` | `0` | 设为 `1` 注册 `agentic_retrieval` 工具 |
-| `MCP_RETRIEVAL_BACKEND` | `relace` | semantic retrieval backend：`relace`、`codanna`、`chunkhound`、`auto`、`none` |
+| `MCP_RETRIEVAL_BACKEND` | `relace` | semantic retrieval backend：`relace`、`codanna`、`chunkhound`、`none` |
 | `MCP_BACKGROUND_INDEX_MONITOR` | `0` | 为 local index 启用可选的周期 refresh monitor；要求 `MCP_BASE_DIR` 与 local backend |
 | `MCP_BACKGROUND_INDEX_INTERVAL_SECONDS` | `300` | 周期 local index 检查间隔 |
 | `MCP_BACKGROUND_INDEX_INITIAL_DELAY_SECONDS` | `30` | server 启动后首次周期 local index 检查前的延迟 |
 
-> **注意：** 仅当**同时满足**以下条件时可省略 `RELACE_API_KEY`：(1) `APPLY_PROVIDER` 和 `SEARCH_PROVIDER` 均使用非 Relace 提供商，且 (2) `RELACE_CLOUD_TOOLS=false`。否则必须设置。
+> **注意：** 仅当**同时满足**以下条件时可省略 `RELACE_API_KEY`：(1) `APPLY_PROVIDER` 和 `SEARCH_PROVIDER` 均使用非 Relace 提供商，且 (2) `MCP_RETRIEVAL_BACKEND` 为 `codanna`、`chunkhound` 或 `none`。否则必须设置。
 
 > **警告：** `MCP_LOGGING=full` 会将**所有**内容以明文写入磁盘，包括源码片段、LLM 指令、工具参数、搜索查询、命令输出及含堆栈追踪的错误信息。请仅在可信环境调试时使用 `full` 模式。`safe` 模式会将敏感字段值替换为 `[REDACTED len=<N> sha256=<HEX12>]` 占位符——sha256 前缀可在不暴露内容的情况下跨事件关联被遮蔽的值。
 
@@ -150,7 +149,7 @@ SEARCH_MAX_TURNS=6
 
 ## 本地检索后端
 
-`agentic_retrieval` 会先用语义检索对文件做预排序，再回到 live code 进行确认。默认使用 Relace 云端索引（`relace` 后端，需要 `RELACE_CLOUD_TOOLS=1` 并已完成 sync）。如需离线使用，可切换为本地后端。
+`agentic_retrieval` 会先用语义检索对文件做预排序，再回到 live code 进行确认。默认使用 Relace 云端索引（`relace` 后端，需要 `RELACE_API_KEY` 且已完成 sync）。如需离线使用，可切换为本地后端。
 
 ### Hint Freshness Policy
 
@@ -193,17 +192,6 @@ MCP_RETRIEVAL_BACKEND=chunkhound
 
 如果 index 缺失或过期，server 可能会先在没有 hints 的情况下继续查询，同时排程 background refresh。使用 `MCP_RETRIEVAL_HINT_POLICY=prefer-stale` 时，retrieval 仍可使用 stale ChunkHound hints；`strict` 会跳过它们。更多配置请参阅 [ChunkHound 项目](https://pypi.org/project/chunkhound/)。
 
-### 自动模式
-
-```bash
-MCP_SEARCH_RETRIEVAL=1
-MCP_RETRIEVAL_BACKEND=auto
-```
-
-Server 按优先级自动选择当前 session 可用的后端：`codanna` → `chunkhound` → `relace`（云端兜底）。
-
-当选中的本地后端处于 stale 或 missing 状态时，retrieval 可以排程 background refresh；query path 不会等待 rebuild 完成。
-
 ### Background Index Monitor
 
 ```bash
@@ -213,17 +201,17 @@ MCP_BASE_DIR=/absolute/path/to/repo
 MCP_BACKGROUND_INDEX_MONITOR=1
 ```
 
-`index_status` 只会在 `RELACE_CLOUD_TOOLS=1`，或 `PATH` 中可发现本地 index CLI（`codanna` / `chunkhound`）时暴露。
+`index_status` 只会在 `MCP_RETRIEVAL_BACKEND` 为 `relace`、`codanna` 或 `chunkhound` 时暴露。
 
 启用后，server 会定期检查当前 local backend 的 freshness，并在需要时触发 background refresh。
 
 - 默认关闭。
 - 只有在 `MCP_BASE_DIR` 固定到单一 repo 时才会启动。
-- 只监控当前生效的 local backend（`codanna`、`chunkhound`，或 `auto` 选中的 local backend）。
+- 只监控当前生效的 local backend（`codanna` 或 `chunkhound`）。
 - 会使用 host-local file lock，避免多个本地 MCP process 意外指向同一 repo 时重复启动 index CLI。
 - 设计目标是单进程部署。若是 multi-worker 或 multi-pod HTTP 部署，请关闭它，改用 backend 自带的 watch/daemon 或外部 scheduler。
 
-`index_status` 会返回 `background_monitor` 摘要，方便确认 monitor 是否真的在运行，以及为何没有运行。
+`index_status` 会返回精简后的 `background_monitor` 摘要，方便确认 monitor 当前状态，以及阻塞原因。
 
 ---
 
@@ -293,13 +281,13 @@ Trace 日志也是 JSONL 格式，每行一个事件。
 | `tool_call` | 工具调用（含计时） |
 | `search_complete` | 搜索完成 |
 | `search_error` | 搜索失败 |
-| `index_status` | 索引后端汇总（relace/codanna/chunkhound） |
+| `index_status` | 当前 active 索引后端摘要 |
 | `index_status_error` | 索引状态错误（如 base_dir 解析失败） |
 | `backend_index_start` | Codanna/ChunkHound 索引开始 |
 | `backend_index_complete` | Codanna/ChunkHound 索引完成 |
 | `backend_index_error` | Codanna/ChunkHound 索引失败 |
 | `backend_disabled` | 后端已禁用（如 CLI 缺失） |
-| `retrieval_backend_selected` | 检索后端选择（含 auto） |
+| `retrieval_backend_selected` | 检索后端选择 |
 | `retrieval_hints_skipped` | 因 policy 或 backend freshness 不允许而跳过 retrieval hints |
 | `retrieval_hints_complete` | 检索提示完成 |
 | `retrieval_hints_error` | 检索提示失败（兜底继续） |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -77,19 +77,19 @@ Search the codebase and return relevant files and line ranges.
 
 ## `index_status`
 
-Available when `RELACE_CLOUD_TOOLS=1` or a local index CLI (`codanna` / `chunkhound`) is discoverable in `PATH`.
+Available when `MCP_RETRIEVAL_BACKEND` is `relace`, `codanna`, or `chunkhound`.
 
-Inspect cloud/local indexing readiness.
+Inspect the single active indexing backend without mutating index state.
 
 This tool takes no parameters.
 
-Returns readiness information for `relace`, `codanna`, and `chunkhound`, plus suggested next actions when needed.
+Returns `active_backend`, a single `backend` status object, and a compact `background_monitor` summary (`state`, `reason`).
 
 ---
 
 ## `cloud_sync`
 
-Available only when `RELACE_CLOUD_TOOLS=1`.
+Available only when `MCP_RETRIEVAL_BACKEND=relace`.
 
 Synchronize the local codebase to Relace Cloud for semantic search.
 
@@ -106,7 +106,7 @@ Synchronize the local codebase to Relace Cloud for semantic search.
 
 ## `cloud_search`
 
-Available only when `RELACE_CLOUD_TOOLS=1`.
+Available only when `MCP_RETRIEVAL_BACKEND=relace`.
 
 Semantic code search over the cloud-synced repository. Requires running `cloud_sync` first.
 
@@ -121,7 +121,7 @@ Semantic code search over the cloud-synced repository. Requires running `cloud_s
 
 ## `cloud_list`
 
-Available only when `RELACE_CLOUD_TOOLS=1`.
+Available only when `MCP_RETRIEVAL_BACKEND=relace`.
 
 List repositories in your Relace Cloud account. Use this to find `repo_id` for `cloud_clear`.
 
@@ -131,7 +131,7 @@ This tool takes no parameters.
 
 ## `cloud_clear`
 
-Available only when `RELACE_CLOUD_TOOLS=1`.
+Available only when `MCP_RETRIEVAL_BACKEND=relace`.
 
 Delete the cloud repository and local sync state.
 
@@ -169,7 +169,6 @@ Set `MCP_RETRIEVAL_BACKEND` to choose a backend. Default: `relace`.
 
 | Value | Requires | Description |
 |-------|----------|-------------|
-| `auto` | — | Auto-detect: prefers Codanna -> ChunkHound -> Relace |
 | `codanna` | `codanna` CLI | Symbol-level semantic search (local) |
 | `chunkhound` | `chunkhound` CLI + embedding API key | Chunk-level semantic search (local) |
 | `relace` | `RELACE_API_KEY` | Cloud-based semantic search |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -79,11 +79,15 @@ Search the codebase and return relevant files and line ranges.
 
 Available when `MCP_RETRIEVAL_BACKEND` is `relace`, `codanna`, or `chunkhound`.
 
-Inspect the single active indexing backend without mutating index state.
+Inspect the single active indexing backend in read-only mode.
 
 This tool takes no parameters.
 
-Returns `active_backend`, a single `backend` status object, and a compact `background_monitor` summary (`state`, `reason`).
+Use this before retrieval when you need to know whether the active backend is fresh and whether semantic hints are usable.
+
+Returns `active_backend`, a single `backend` status object with `freshness` and `hints_usable`, and `background_monitor` (`state`, `reason`).
+
+This tool never refreshes indexes. If `active_backend` is `relace` and `backend.status.needs_sync` is `true`, run `cloud_sync()`.
 
 ---
 

--- a/docs/tools.zh-CN.md
+++ b/docs/tools.zh-CN.md
@@ -79,11 +79,15 @@
 
 仅在 `MCP_RETRIEVAL_BACKEND` 为 `relace`、`codanna` 或 `chunkhound` 时可用。
 
-检查当前唯一 active backend 的索引状态，不会修改 index。
+以只读方式检查当前唯一 active backend 的索引状态。
 
 此工具不接受参数。
 
-返回 `active_backend`、单一的 `backend` 状态对象，以及精简后的 `background_monitor` 摘要（`state`、`reason`）。
+适合在 retrieval 前先判断当前 backend 是否够新，以及 semantic hints 是否可用。
+
+返回 `active_backend`、单一的 `backend` 状态对象（包含 `freshness`、`hints_usable`），以及 `background_monitor` 摘要（`state`、`reason`）。
+
+此工具不会主动刷新 index。若 `active_backend` 是 `relace` 且 `backend.status.needs_sync` 为 `true`，请运行 `cloud_sync()`。
 
 ---
 

--- a/docs/tools.zh-CN.md
+++ b/docs/tools.zh-CN.md
@@ -77,19 +77,19 @@
 
 ## `index_status`
 
-仅在 `RELACE_CLOUD_TOOLS=1`，或 `PATH` 中可发现本地 index CLI（`codanna` / `chunkhound`）时可用。
+仅在 `MCP_RETRIEVAL_BACKEND` 为 `relace`、`codanna` 或 `chunkhound` 时可用。
 
-检查 cloud/local 索引就绪状态。
+检查当前唯一 active backend 的索引状态，不会修改 index。
 
 此工具不接受参数。
 
-返回 `relace`、`codanna`、`chunkhound` 的就绪信息，以及需要时的下一步建议。
+返回 `active_backend`、单一的 `backend` 状态对象，以及精简后的 `background_monitor` 摘要（`state`、`reason`）。
 
 ---
 
 ## `cloud_sync`
 
-仅在 `RELACE_CLOUD_TOOLS=1` 时可用。
+仅在 `MCP_RETRIEVAL_BACKEND=relace` 时可用。
 
 将本地代码库同步到 Relace Cloud 以进行语义搜索。
 
@@ -106,7 +106,7 @@
 
 ## `cloud_search`
 
-仅在 `RELACE_CLOUD_TOOLS=1` 时可用。
+仅在 `MCP_RETRIEVAL_BACKEND=relace` 时可用。
 
 对云端同步的仓库进行语义代码搜索。需要先运行 `cloud_sync`。
 
@@ -121,7 +121,7 @@
 
 ## `cloud_list`
 
-仅在 `RELACE_CLOUD_TOOLS=1` 时可用。
+仅在 `MCP_RETRIEVAL_BACKEND=relace` 时可用。
 
 列出 Relace Cloud 账户中的仓库。可用它获取 `cloud_clear` 所需的 `repo_id`。
 
@@ -131,7 +131,7 @@
 
 ## `cloud_clear`
 
-仅在 `RELACE_CLOUD_TOOLS=1` 时可用。
+仅在 `MCP_RETRIEVAL_BACKEND=relace` 时可用。
 
 删除云端仓库和本地同步状态。
 
@@ -169,7 +169,6 @@
 
 | 值 | 依赖 | 说明 |
 |----|------|------|
-| `auto` | — | 自动检测：优先 Codanna -> ChunkHound -> Relace |
 | `codanna` | `codanna` CLI | 符号级语义搜索（本地） |
 | `chunkhound` | `chunkhound` CLI + embedding API key | 代码块级语义搜索（本地） |
 | `relace` | `RELACE_API_KEY` | 云端语义搜索 |

--- a/src/relace_mcp/config/__init__.py
+++ b/src/relace_mcp/config/__init__.py
@@ -6,6 +6,12 @@ import yaml
 
 from . import settings as _settings
 from .base_dir import invalidate_roots_cache, resolve_base_dir
+from .indexing import (
+    LOCAL_INDEX_BACKENDS,
+    IndexRuntime,
+    resolve_index_runtime,
+    validate_index_settings,
+)
 from .provider import ProviderConfig, create_provider_config
 from .settings import RelaceConfig
 
@@ -82,9 +88,13 @@ def load_apply_system_prompt() -> str:
 __all__ = [
     "RelaceConfig",
     "ProviderConfig",
+    "IndexRuntime",
+    "LOCAL_INDEX_BACKENDS",
     "create_provider_config",
     "resolve_base_dir",
+    "resolve_index_runtime",
     "invalidate_roots_cache",
     "load_prompt_file",
     "load_apply_system_prompt",
+    "validate_index_settings",
 ]

--- a/src/relace_mcp/config/base_dir.py
+++ b/src/relace_mcp/config/base_dir.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 _MAX_CACHE_SIZE = 100
 _roots_cache: dict[str, tuple[str, str]] = {}
-_BLOCKED_MCP_ROOTS = (Path.home() / ".codeium" / "windsurf",)
+_BLOCKED_MCP_ROOTS = ((Path.home() / ".codeium" / "windsurf").resolve(),)
 
 
 def _roots_cache_key(ctx: "Context | None") -> str | None:

--- a/src/relace_mcp/config/base_dir.py
+++ b/src/relace_mcp/config/base_dir.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 _MAX_CACHE_SIZE = 100
 _roots_cache: dict[str, tuple[str, str]] = {}
+_BLOCKED_MCP_ROOTS = (Path.home() / ".codeium" / "windsurf",)
 
 
 def _roots_cache_key(ctx: "Context | None") -> str | None:
@@ -58,6 +59,14 @@ def _cache_roots(key: str, resolved: str, source: str) -> None:
     if len(_roots_cache) >= _MAX_CACHE_SIZE:
         _roots_cache.clear()
     _roots_cache[key] = (resolved, source)
+
+
+def _is_blocked_mcp_root(path: str) -> bool:
+    try:
+        resolved = Path(path).resolve()
+    except OSError:
+        return False
+    return resolved in _BLOCKED_MCP_ROOTS
 
 
 PROJECT_MARKERS = (".git", "pyproject.toml", "package.json", "Cargo.toml", "go.mod", ".project")
@@ -133,7 +142,7 @@ def _select_best_root(roots: "Sequence[Root]") -> str:
     for r in roots:
         try:
             p = str(Path(uri_to_path(str(r.uri))).resolve())
-            if _is_accessible_directory(p):
+            if _is_accessible_directory(p) and not _is_blocked_mcp_root(p):
                 root_paths.append(p)
         except Exception:  # nosec B112
             continue
@@ -189,7 +198,7 @@ async def resolve_base_dir(
     # 2. Cached MCP Roots
     cache_key = _roots_cache_key(ctx)
     if cache_key and (cached := _roots_cache.get(cache_key)):
-        if _is_accessible_directory(cached[0]):
+        if _is_accessible_directory(cached[0]) and not _is_blocked_mcp_root(cached[0]):
             logger.debug("[base_dir] resolved=%s source=%s (cached)", cached[0], cached[1])
             return cached
         _roots_cache.pop(cache_key, None)
@@ -209,7 +218,7 @@ async def resolve_base_dir(
                     path = _select_best_root(roots)
                     source = f"MCP Root (selected from {len(roots)} roots)"
                 resolved = str(Path(path).resolve())
-                if _is_accessible_directory(resolved):
+                if _is_accessible_directory(resolved) and not _is_blocked_mcp_root(resolved):
                     if cache_key:
                         _cache_roots(cache_key, resolved, source)
                     logger.debug("[base_dir] resolved=%s source=%s", resolved, source)

--- a/src/relace_mcp/config/indexing.py
+++ b/src/relace_mcp/config/indexing.py
@@ -1,13 +1,15 @@
 from dataclasses import dataclass
+from typing import Literal
 
 from . import settings as _settings
 
 LOCAL_INDEX_BACKENDS = frozenset({"codanna", "chunkhound"})
+RetrievalBackend = Literal["relace", "codanna", "chunkhound", "none"]
 
 
 @dataclass(frozen=True, slots=True)
 class IndexRuntime:
-    active_backend: str
+    active_backend: RetrievalBackend
     cloud_tools_enabled: bool
     index_status_enabled: bool
     local_backend_enabled: bool

--- a/src/relace_mcp/config/indexing.py
+++ b/src/relace_mcp/config/indexing.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+
+from . import settings as _settings
+
+LOCAL_INDEX_BACKENDS = frozenset({"codanna", "chunkhound"})
+
+
+@dataclass(frozen=True, slots=True)
+class IndexRuntime:
+    active_backend: str
+    cloud_tools_enabled: bool
+    index_status_enabled: bool
+    local_backend_enabled: bool
+    background_monitor_allowed: bool
+
+
+def validate_index_settings(*, api_key: str | None) -> None:
+    backend = _settings.RETRIEVAL_BACKEND
+
+    if backend == "relace" and not api_key:
+        raise RuntimeError(
+            "RELACE_API_KEY is required when MCP_RETRIEVAL_BACKEND=relace. "
+            "Set RELACE_API_KEY or choose MCP_RETRIEVAL_BACKEND=codanna, chunkhound, or none."
+        )
+
+
+def resolve_index_runtime(
+    *,
+    base_dir: str | None,
+) -> IndexRuntime:
+    active_backend = _settings.RETRIEVAL_BACKEND
+    local_backend_enabled = active_backend in LOCAL_INDEX_BACKENDS
+    cloud_tools_enabled = active_backend == "relace"
+    index_status_enabled = active_backend != "none"
+    background_monitor_allowed = (
+        local_backend_enabled
+        and _settings.MCP_BACKGROUND_INDEX_MONITOR
+        and _settings.AGENTIC_RETRIEVAL_ENABLED
+        and bool(base_dir)
+    )
+    return IndexRuntime(
+        active_backend=active_backend,
+        cloud_tools_enabled=cloud_tools_enabled,
+        index_status_enabled=index_status_enabled,
+        local_backend_enabled=local_backend_enabled,
+        background_monitor_allowed=background_monitor_allowed,
+    )

--- a/src/relace_mcp/config/settings.py
+++ b/src/relace_mcp/config/settings.py
@@ -11,7 +11,6 @@ from .compat import env_bool
 logger = logging.getLogger(__name__)
 
 __all__ = [
-    "RELACE_CLOUD_TOOLS",
     "RETRIEVAL_BACKEND",
     "SEARCH_BASH_TOOLS",
     "SEARCH_LSP_TOOLS",
@@ -54,7 +53,7 @@ TRACE_DIR = LOG_DIR / "traces"
 TRACE_PATH = TRACE_DIR / "relace.trace.jsonl"
 MAX_TRACE_LOG_SIZE_BYTES = 50 * 1024 * 1024
 
-_ALLOWED_RETRIEVAL_BACKENDS = {"relace", "codanna", "chunkhound", "none", "auto"}
+_ALLOWED_RETRIEVAL_BACKENDS = {"relace", "codanna", "chunkhound", "none"}
 _ALLOWED_RETRIEVAL_HINT_POLICIES = {"prefer-stale", "strict"}
 _ALLOWED_SEARCH_TURN_STATUS_MODES = {"always", "final-only", "off"}
 
@@ -141,6 +140,11 @@ def _parse_log_level() -> str:
 
 def _parse_retrieval_backend() -> str:
     raw = os.getenv("MCP_RETRIEVAL_BACKEND", "relace").strip().lower()
+    if raw == "auto":
+        raise RuntimeError(
+            "MCP_RETRIEVAL_BACKEND=auto is no longer supported. "
+            "Set MCP_RETRIEVAL_BACKEND to one of: relace, codanna, chunkhound, none."
+        )
     if raw not in _ALLOWED_RETRIEVAL_BACKENDS:
         raise RuntimeError(
             f"Invalid MCP_RETRIEVAL_BACKEND={raw!r}. "
@@ -224,7 +228,6 @@ MCP_LOGGING_MODE: str
 MCP_LOGGING: bool
 MCP_LOG_REDACT: bool
 MCP_TRACE_LOGGING: bool
-RELACE_CLOUD_TOOLS: bool
 RETRIEVAL_BACKEND: str
 RETRIEVAL_HINT_POLICY: str
 AGENTIC_RETRIEVAL_ENABLED: bool
@@ -242,7 +245,6 @@ RELACE_API_KEY: str | None
 MCP_BASE_DIR: str | None
 MCP_EXTRA_PATHS: tuple[str, ...]
 
-RELACE_CLOUD_TOOLS = False
 RELACE_API_KEY = None
 MCP_BASE_DIR = None
 RELACE_DEFAULT_ENCODING = None
@@ -282,7 +284,6 @@ def reload_settings_from_env() -> None:
         "APPLY_SEMANTIC_CHECK": env_bool("APPLY_SEMANTIC_CHECK", default=False),
         "MCP_LOG_LEVEL": _parse_log_level(),
         "MCP_LOGGING_MODE": _parse_logging_mode(),
-        "RELACE_CLOUD_TOOLS": env_bool("RELACE_CLOUD_TOOLS", default=False),
         "RETRIEVAL_BACKEND": _parse_retrieval_backend(),
         "RETRIEVAL_HINT_POLICY": _parse_retrieval_hint_policy(),
         "AGENTIC_RETRIEVAL_ENABLED": env_bool("MCP_SEARCH_RETRIEVAL", default=False),
@@ -338,11 +339,9 @@ class RelaceConfig:
         reload_settings_from_env()
         api_key = RELACE_API_KEY
 
-        if RELACE_CLOUD_TOOLS and not api_key:
-            raise RuntimeError(
-                "RELACE_API_KEY is required when RELACE_CLOUD_TOOLS=true. "
-                "Set RELACE_CLOUD_TOOLS=false or provide RELACE_API_KEY."
-            )
+        from .indexing import validate_index_settings
+
+        validate_index_settings(api_key=api_key)
 
         base_dir = MCP_BASE_DIR
         if base_dir:

--- a/src/relace_mcp/config/settings.py
+++ b/src/relace_mcp/config/settings.py
@@ -3,6 +3,7 @@ import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal, cast
 
 from platformdirs import user_state_dir
 
@@ -63,6 +64,8 @@ _LINUX_DEFAULT_EXTRA_PATHS: tuple[str, ...] = (
     "~/.gemini/antigravity/brain",
     "~/.kiro/steering",
 )
+
+RetrievalBackend = Literal["relace", "codanna", "chunkhound", "none"]
 
 
 def _parse_positive_int_env(name: str, default: int) -> int:
@@ -138,7 +141,7 @@ def _parse_log_level() -> str:
     return (os.getenv("MCP_LOG_LEVEL", "WARNING").strip() or "WARNING").upper()
 
 
-def _parse_retrieval_backend() -> str:
+def _parse_retrieval_backend() -> RetrievalBackend:
     raw = os.getenv("MCP_RETRIEVAL_BACKEND", "relace").strip().lower()
     if raw == "auto":
         raise RuntimeError(
@@ -150,7 +153,7 @@ def _parse_retrieval_backend() -> str:
             f"Invalid MCP_RETRIEVAL_BACKEND={raw!r}. "
             f"Expected one of: {sorted(_ALLOWED_RETRIEVAL_BACKENDS)}"
         )
-    return raw
+    return cast(RetrievalBackend, raw)
 
 
 def _parse_retrieval_hint_policy() -> str:
@@ -228,7 +231,7 @@ MCP_LOGGING_MODE: str
 MCP_LOGGING: bool
 MCP_LOG_REDACT: bool
 MCP_TRACE_LOGGING: bool
-RETRIEVAL_BACKEND: str
+RETRIEVAL_BACKEND: RetrievalBackend
 RETRIEVAL_HINT_POLICY: str
 AGENTIC_RETRIEVAL_ENABLED: bool
 SEARCH_TOOL_STRICT: bool

--- a/src/relace_mcp/repo/backends/chunkhound.py
+++ b/src/relace_mcp/repo/backends/chunkhound.py
@@ -111,9 +111,6 @@ def chunkhound_auto_reindex(base_dir: str) -> dict[str, Any]:
 
     try:
         _ensure_chunkhound_index(base_dir, env)
-        _write_indexed_head(base_dir, head, _CHUNKHOUND_HEAD_FILE)
-        if is_git_dirty(base_dir):
-            _write_dirty_ts(base_dir, _CHUNKHOUND_DIRTY_TS_FILE)
         logger.info("ChunkHound auto-reindex completed")
         return {"action": "reindexed", "old_head": last_head, "new_head": head}
     except (RuntimeError, OSError) as exc:
@@ -315,6 +312,7 @@ def _ensure_chunkhound_index(base_dir: str, env: dict[str, str]) -> None:
             "stderr_len": len(result.stderr or ""),
         }
     )
+    _mark_chunkhound_index_fresh(base_dir)
     logger.debug("ChunkHound index created successfully")
 
 
@@ -482,7 +480,7 @@ def chunkhound_index_file(file_path: str, base_dir: str) -> None:
     env["LC_ALL"] = "C.UTF-8"
     try:
         _ensure_chunkhound_index(base_dir, env)
-        logger.debug("ChunkHound incremental reindex triggered by edit: %s", file_path)
+        logger.debug("ChunkHound full reindex triggered by edit: %s", file_path)
     except RuntimeError as exc:
         kind = "cli_not_found" if isinstance(exc.__cause__, FileNotFoundError) else "nonzero_exit"
         raise ExternalCLIError(

--- a/src/relace_mcp/repo/backends/codanna.py
+++ b/src/relace_mcp/repo/backends/codanna.py
@@ -1,6 +1,5 @@
 from .codanna_indexing import (
     _async_run_codanna_full_index,
-    _async_run_codanna_index,
     _build_codanna_env,
     _ensure_codanna_index,
     codanna_auto_reindex,
@@ -17,7 +16,6 @@ from .codanna_search import (
 
 __all__ = [
     "_async_run_codanna_full_index",
-    "_async_run_codanna_index",
     "_build_codanna_env",
     "_codanna_health_probe",
     "_ensure_codanna_index",

--- a/src/relace_mcp/repo/backends/codanna_indexing.py
+++ b/src/relace_mcp/repo/backends/codanna_indexing.py
@@ -18,10 +18,8 @@ from .index_state import (
 )
 from .locking import BackendIndexRunResult, try_acquire_backend_index_lock
 from .registry import (
-    _bg_codanna_pending,
     _bg_index_rerun,
     _bg_index_tasks,
-    disable_backend,
     is_bg_index_running,
 )
 
@@ -41,13 +39,6 @@ def _build_codanna_env() -> dict[str, str]:
     env["LANG"] = "C.UTF-8"
     env["LC_ALL"] = "C.UTF-8"
     return env
-
-
-def _resolve_codanna_rel_path(file_path: str, base_dir: str) -> str:
-    try:
-        return os.path.relpath(file_path, base_dir)
-    except ValueError:
-        return file_path
 
 
 def _codanna_command_prefix(op: str) -> str:
@@ -275,9 +266,6 @@ def codanna_auto_reindex(base_dir: str) -> dict[str, Any]:
 
     try:
         _ensure_codanna_index(base_dir, _build_codanna_env())
-        _write_indexed_head(base_dir, head, _CODANNA_HEAD_FILE)
-        if is_git_dirty(base_dir):
-            _write_dirty_ts(base_dir, _CODANNA_DIRTY_TS_FILE)
         logger.info("Codanna auto-reindex completed")
         return {"action": "reindexed", "old_head": last_head, "new_head": head}
     except (RuntimeError, OSError) as exc:
@@ -304,246 +292,14 @@ def _ensure_codanna_index(base_dir: str, env: dict[str, str]) -> None:
         op="index",
         background=False,
     )
+    _mark_codanna_index_fresh(base_dir)
     logger.debug("Codanna index created successfully")
 
 
 def codanna_index_file(file_path: str, base_dir: str) -> None:
-    """Incrementally update Codanna index for a single edited file."""
-    rel_path = _resolve_codanna_rel_path(file_path, base_dir)
-    _run_sync_codanna_command(
-        ["codanna", "index", rel_path],
-        base_dir=base_dir,
-        env=_build_codanna_env(),
-        timeout_s=120,
-        op="index_file",
-        background=False,
-        file_path=file_path,
-        rel_path=rel_path,
-    )
-    logger.debug("Codanna incremental reindex triggered by edit: %s", rel_path)
-
-
-async def _async_run_codanna_index(file_path: str, base_dir: str) -> BackendIndexRunResult:
-    env = _build_codanna_env()
-    rel_path = _resolve_codanna_rel_path(file_path, base_dir)
-    command = ["codanna", "index", rel_path]
-    timeout_s = 120
-    started = time.perf_counter()
-    payload = _codanna_log_fields(
-        command,
-        base_dir=base_dir,
-        timeout_s=timeout_s,
-        op="index_file",
-        background=True,
-        file_path=file_path,
-        rel_path=rel_path,
-    )
-
-    log_event({"kind": "backend_index_start", "level": "info", **payload})
-    log_trace_event(
-        {
-            "kind": "cli_request",
-            "cli": "codanna",
-            "mode": "text",
-            "env_keys": sorted(env.keys()),
-            **payload,
-        }
-    )
-
-    lease = try_acquire_backend_index_lock(base_dir, "codanna")
-    if not lease.acquired:
-        log_event(
-            {
-                "kind": "backend_index_skipped",
-                "level": "info",
-                "reason": lease.reason,
-                "lock_path": lease.lock_path,
-                **payload,
-            }
-        )
-        logger.info("Codanna background index skipped for %s (%s)", rel_path, lease.reason)
-        return BackendIndexRunResult(
-            status="lock_held" if lease.reason == "lock_held" else "lock_error",
-            reason=lease.reason,
-            lock_path=lease.lock_path,
-        )
-
-    try:
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "codanna",
-                "index",
-                rel_path,
-                cwd=base_dir,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-            )
-        except FileNotFoundError as exc:
-            latency_ms = int((time.perf_counter() - started) * 1000)
-            logger.warning("codanna CLI not found in background index; disabling backend")
-            disable_backend("codanna", "cli_not_found: codanna not in PATH")
-            log_trace_event(
-                {
-                    "kind": "cli_error",
-                    "cli": "codanna",
-                    "mode": "text",
-                    "error_type": type(exc).__name__,
-                    "error": str(exc),
-                    **payload,
-                }
-            )
-            log_event(
-                {
-                    "kind": "backend_index_error",
-                    "level": "error",
-                    "latency_ms": latency_ms,
-                    "error_kind": "cli_not_found",
-                    "error": "codanna CLI not found",
-                    "lock_path": lease.lock_path,
-                    **payload,
-                }
-            )
-            return BackendIndexRunResult(
-                status="cli_not_found",
-                reason="codanna CLI not found",
-                lock_path=lease.lock_path,
-            )
-        except OSError as exc:
-            latency_ms = int((time.perf_counter() - started) * 1000)
-            logger.warning("codanna background index failed to start: %s", exc)
-            log_trace_event(
-                {
-                    "kind": "cli_error",
-                    "cli": "codanna",
-                    "mode": "text",
-                    "error_type": type(exc).__name__,
-                    "error": str(exc),
-                    **payload,
-                }
-            )
-            log_event(
-                {
-                    "kind": "backend_index_error",
-                    "level": "error",
-                    "latency_ms": latency_ms,
-                    "error_kind": "os_error",
-                    "error": redact_value(str(exc), 500),
-                    "lock_path": lease.lock_path,
-                    **payload,
-                }
-            )
-            return BackendIndexRunResult(
-                status="spawn_error",
-                reason=str(exc),
-                lock_path=lease.lock_path,
-            )
-
-        try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                proc.communicate(), timeout=timeout_s
-            )
-        except TimeoutError as exc:
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                pass
-            latency_ms = int((time.perf_counter() - started) * 1000)
-            logger.warning("Codanna background index timed out for %s", rel_path)
-            log_trace_event(
-                {
-                    "kind": "cli_error",
-                    "cli": "codanna",
-                    "mode": "text",
-                    "error_type": type(exc).__name__,
-                    "error": str(exc),
-                    **payload,
-                }
-            )
-            log_event(
-                {
-                    "kind": "backend_index_error",
-                    "level": "error",
-                    "latency_ms": latency_ms,
-                    "error_kind": "timeout",
-                    "error": "codanna index timed out",
-                    "lock_path": lease.lock_path,
-                    **payload,
-                }
-            )
-            return BackendIndexRunResult(
-                status="timeout",
-                reason="codanna index timed out",
-                lock_path=lease.lock_path,
-            )
-
-        latency_ms = int((time.perf_counter() - started) * 1000)
-        stdout = (stdout_bytes or b"").decode("utf-8", errors="replace")
-        stderr = (stderr_bytes or b"").decode("utf-8", errors="replace")
-
-        if proc.returncode != 0:
-            stderr_str = stderr.strip()
-            logger.warning(
-                "Codanna background index failed (exit %d): %s",
-                proc.returncode,
-                stderr_str,
-            )
-            log_trace_event(
-                {
-                    "kind": "cli_error",
-                    "cli": "codanna",
-                    "mode": "text",
-                    "returncode": proc.returncode,
-                    "stdout": stdout,
-                    "stderr": stderr,
-                    "detail": stderr_str,
-                    **payload,
-                }
-            )
-            log_event(
-                {
-                    "kind": "backend_index_error",
-                    "level": "error",
-                    "latency_ms": latency_ms,
-                    "returncode": proc.returncode,
-                    "stderr_preview": redact_value(stderr_str, 500),
-                    "lock_path": lease.lock_path,
-                    **payload,
-                }
-            )
-            return BackendIndexRunResult(
-                status="nonzero_exit",
-                reason=stderr_str,
-                lock_path=lease.lock_path,
-            )
-
-        log_trace_event(
-            {
-                "kind": "cli_response",
-                "cli": "codanna",
-                "mode": "text",
-                "returncode": proc.returncode,
-                "stdout": stdout,
-                "stderr": stderr,
-                **payload,
-            }
-        )
-        log_event(
-            {
-                "kind": "backend_index_complete",
-                "level": "info",
-                "latency_ms": latency_ms,
-                "returncode": proc.returncode,
-                "stdout_len": len(stdout),
-                "stderr_len": len(stderr),
-                "lock_path": lease.lock_path,
-                **payload,
-            }
-        )
-        logger.debug("Codanna background index completed for %s", rel_path)
-        return BackendIndexRunResult(status="completed", lock_path=lease.lock_path)
-    finally:
-        lease.release()
+    """Refresh the full Codanna index after a file edit."""
+    _ensure_codanna_index(base_dir, _build_codanna_env())
+    logger.debug("Codanna full reindex triggered by edit: %s", file_path)
 
 
 async def _async_run_codanna_full_index(base_dir: str) -> BackendIndexRunResult:
@@ -595,7 +351,6 @@ def schedule_bg_codanna_full_index(base_dir: str) -> None:
         return
 
     def _on_done(_task: asyncio.Task[Any]) -> None:
-        _bg_codanna_pending.pop(key, None)
         if _bg_index_rerun.pop(key, False):
             schedule_bg_codanna_full_index(base_dir)
 
@@ -605,28 +360,5 @@ def schedule_bg_codanna_full_index(base_dir: str) -> None:
 
 
 def schedule_bg_codanna_index(file_path: str, base_dir: str) -> None:
-    """Schedule a background Codanna single-file reindex."""
-    key = (base_dir, "codanna")
-    task = _bg_index_tasks.get(key)
-    if task is not None and not task.done():
-        pending = _bg_codanna_pending.get(key)
-        if pending is None:
-            pending = set()
-            _bg_codanna_pending[key] = pending
-        pending.add(file_path)
-        return
-
-    def _on_done(_task: asyncio.Task[Any]) -> None:
-        pending = _bg_codanna_pending.get(key)
-        if not pending:
-            _bg_codanna_pending.pop(key, None)
-            return
-
-        next_path = pending.pop()
-        if not pending:
-            _bg_codanna_pending.pop(key, None)
-        schedule_bg_codanna_index(next_path, base_dir)
-
-    new_task = asyncio.create_task(_async_run_codanna_index(file_path, base_dir))
-    new_task.add_done_callback(_on_done)
-    _bg_index_tasks[key] = new_task
+    """Schedule a background Codanna full refresh after a file edit."""
+    schedule_bg_codanna_full_index(base_dir)

--- a/src/relace_mcp/repo/backends/registry.py
+++ b/src/relace_mcp/repo/backends/registry.py
@@ -10,7 +10,6 @@ _disabled_backends: set[str] = set()
 
 _bg_index_tasks: dict[tuple[str, str], asyncio.Task[Any]] = {}
 _bg_index_rerun: dict[tuple[str, str], bool] = {}
-_bg_codanna_pending: dict[tuple[str, str], set[str]] = {}
 
 
 def is_backend_disabled(name: str) -> bool:

--- a/src/relace_mcp/repo/freshness.py
+++ b/src/relace_mcp/repo/freshness.py
@@ -22,6 +22,14 @@ class FreshnessStatus:
     reason: str | None = None
 
 
+def semantic_hints_usable_for_policy(freshness: str, policy: str) -> bool:
+    if freshness == "missing":
+        return False
+    if policy == "strict":
+        return freshness == "fresh"
+    return freshness in {"fresh", "stale", "unknown"}
+
+
 def _has_local_index_artifacts(base_dir: str, backend: str) -> bool:
     if backend == "codanna":
         artifact_root = os.path.join(base_dir, ".codanna", "index")

--- a/src/relace_mcp/repo/monitor.py
+++ b/src/relace_mcp/repo/monitor.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
 from typing import TYPE_CHECKING, Any
 
+from ..config import IndexRuntime
 from ..config import settings as _settings
 from ..observability import log_event
 from .backends.chunkhound import schedule_bg_chunkhound_index
@@ -29,9 +30,25 @@ _BACKOFF_BASE_SECONDS = 60.0
 _BACKOFF_MAX_SECONDS = 900.0
 
 
+def _monitor_state(*, enabled: bool, requested: bool, reason: str | None) -> str:
+    if enabled:
+        return "active"
+    if not requested:
+        return "disabled"
+    if reason == "uninitialized":
+        return "uninitialized"
+    return "blocked"
+
+
 class BackgroundIndexMonitor:
-    def __init__(self, config: "RelaceConfig") -> None:
+    def __init__(
+        self,
+        config: "RelaceConfig",
+        *,
+        index_runtime: IndexRuntime,
+    ) -> None:
         self._config = config
+        self._index_runtime = index_runtime
         self._requested = _settings.MCP_BACKGROUND_INDEX_MONITOR
         # Settings are captured at construction time. The monitor does not re-read them
         # after start(); restart the server to apply changes to interval/delay.
@@ -57,15 +74,14 @@ class BackgroundIndexMonitor:
     def summary(self) -> dict[str, Any]:
         enabled = self._is_task_running()
         return {
-            "enabled": enabled,
-            "requested": self._requested,
+            "state": _monitor_state(
+                enabled=enabled,
+                requested=self._requested,
+                reason=None if enabled else self._reason,
+            ),
             "reason": None if enabled else self._reason,
-            "active_backend": self._active_backend,
             "interval_seconds": self._interval_seconds if self._requested else None,
             "initial_delay_seconds": self._initial_delay_seconds if self._requested else None,
-            "base_dir": self._config.base_dir,
-            "last_status": self._last_status,
-            "last_error": self._last_error,
         }
 
     @asynccontextmanager
@@ -94,7 +110,7 @@ class BackgroundIndexMonitor:
             {
                 "kind": "background_index_monitor_started",
                 "level": "info",
-                "backend": self._active_backend,
+                "active_backend": self._active_backend,
                 "base_dir": self._config.base_dir,
                 "interval_seconds": self._interval_seconds,
                 "initial_delay_seconds": self._initial_delay_seconds,
@@ -119,21 +135,12 @@ class BackgroundIndexMonitor:
             return None, "agentic_retrieval_disabled"
         if not self._config.base_dir:
             return None, "base_dir_not_pinned"
+        if not self._index_runtime.local_backend_enabled:
+            return None, "backend_not_local"
         if not supports_backend_index_locking():
             return None, "locking_unavailable"
 
-        backend = _settings.RETRIEVAL_BACKEND
-        if backend in ("relace", "none"):
-            return None, "backend_not_local"
-
-        if backend == "auto":
-            for candidate in ("codanna", "chunkhound"):
-                if is_backend_disabled(candidate):
-                    continue
-                if shutil.which(candidate):
-                    return candidate, "ok"
-            return None, "no_local_backend_available"
-
+        backend = self._index_runtime.active_backend
         if is_backend_disabled(backend):
             return None, "backend_disabled"
         if not shutil.which(backend):
@@ -162,10 +169,6 @@ class BackgroundIndexMonitor:
             "backend_not_local": (
                 logging.INFO,
                 "Background index monitor requested but the configured retrieval backend is not local.",
-            ),
-            "no_local_backend_available": (
-                logging.WARNING,
-                "Background index monitor requested but no local retrieval backend CLI is installed.",
             ),
             "backend_disabled": (
                 logging.WARNING,
@@ -262,7 +265,7 @@ class BackgroundIndexMonitor:
             {
                 "kind": "background_index_monitor_tick",
                 "level": "info",
-                "backend": backend,
+                "active_backend": backend,
                 "base_dir": base_dir,
                 "freshness": freshness.freshness,
                 "reason": freshness.reason,
@@ -302,13 +305,8 @@ def get_background_index_monitor_summary(mcp: Any) -> dict[str, Any]:
     if isinstance(monitor, BackgroundIndexMonitor):
         return monitor.summary()
     return {
-        "enabled": False,
-        "requested": False,
+        "state": "uninitialized",
         "reason": "uninitialized",
-        "active_backend": None,
         "interval_seconds": None,
         "initial_delay_seconds": None,
-        "base_dir": None,
-        "last_status": None,
-        "last_error": None,
     }

--- a/src/relace_mcp/search/retrieval.py
+++ b/src/relace_mcp/search/retrieval.py
@@ -33,8 +33,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_auto_backend_cache: dict[str, str] = {}
-
 
 async def _run_blocking_retrieval_call(
     func: Callable[..., Any],
@@ -54,22 +52,6 @@ async def _run_blocking_retrieval_call(
 
     with ThreadPoolExecutor(max_workers=1, thread_name_prefix="relace-retrieval") as executor:
         return await loop.run_in_executor(executor, _call)
-
-
-def _resolve_auto_backend(base_dir: str) -> str:
-    cached = _auto_backend_cache.get(base_dir)
-    if cached and not is_backend_disabled(cached):
-        return cached
-
-    for name in ("codanna", "chunkhound"):
-        if shutil.which(name) and not is_backend_disabled(name):
-            logger.info("Auto-detected retrieval backend: %s", name)
-            _auto_backend_cache[base_dir] = name
-            return name
-
-    logger.info("No usable local retrieval backend found, using relace")
-    _auto_backend_cache[base_dir] = "relace"
-    return "relace"
 
 
 def _backend_display_name(backend: str) -> str:
@@ -207,11 +189,7 @@ async def agentic_retrieval_logic(
     trace_id = get_trace_id() if tool_name_ctx.get() else str(uuid.uuid4())[:8]
     logger.debug("[%s] Starting agentic retrieval", trace_id)
 
-    backend = (
-        _resolve_auto_backend(base_dir)
-        if _settings.RETRIEVAL_BACKEND == "auto"
-        else _settings.RETRIEVAL_BACKEND
-    )
+    backend = _settings.RETRIEVAL_BACKEND
     hint_policy = _settings.RETRIEVAL_HINT_POLICY
 
     log_event(
@@ -386,7 +364,7 @@ async def agentic_retrieval_logic(
             hints_index_freshness = "missing"
             _append_warning(
                 warnings_list,
-                "Relace semantic retrieval unavailable (RELACE_CLOUD_TOOLS=false). Proceeding without hints.",
+                "Relace semantic retrieval unavailable. Proceeding without hints.",
             )
         else:
             freshness = classify_cloud_index_freshness(base_dir)

--- a/src/relace_mcp/search/retrieval.py
+++ b/src/relace_mcp/search/retrieval.py
@@ -22,7 +22,11 @@ from ..repo.backends import (
     schedule_bg_codanna_full_index,
 )
 from ..repo.cloud.search import cloud_search_logic
-from ..repo.freshness import classify_cloud_index_freshness, classify_local_index_freshness
+from ..repo.freshness import (
+    classify_cloud_index_freshness,
+    classify_local_index_freshness,
+    semantic_hints_usable_for_policy,
+)
 from ..utils import resolve_repo_path
 from .harness import FastAgenticSearchHarness
 from .prompt_messages import format_hints_list
@@ -67,14 +71,6 @@ def _backend_display_name(backend: str) -> str:
 def _append_warning(warnings_list: list[str], message: str) -> None:
     if message not in warnings_list:
         warnings_list.append(message)
-
-
-def _should_use_semantic_hints(policy: str, freshness: str) -> bool:
-    if freshness == "missing":
-        return False
-    if policy == "strict":
-        return freshness == "fresh"
-    return freshness in {"fresh", "stale", "unknown"}
 
 
 def _schedule_local_refresh(base_dir: str, backend: str) -> bool:
@@ -248,7 +244,7 @@ async def agentic_retrieval_logic(
                 background_refresh_scheduled = True
                 reindex_action = "scheduled_background_refresh"
 
-            if not _should_use_semantic_hints(hint_policy, freshness.freshness):
+            if not semantic_hints_usable_for_policy(freshness.freshness, hint_policy):
                 if freshness.freshness == "missing":
                     message = (
                         f"{backend_name} index missing. Proceeding without hints"
@@ -370,7 +366,7 @@ async def agentic_retrieval_logic(
             freshness = classify_cloud_index_freshness(base_dir)
             hints_index_freshness = freshness.freshness
 
-            if not _should_use_semantic_hints(hint_policy, freshness.freshness):
+            if not semantic_hints_usable_for_policy(freshness.freshness, hint_policy):
                 if freshness.freshness == "missing":
                     message = (
                         "No synced Relace index found. Proceeding without hints. "

--- a/src/relace_mcp/server.py
+++ b/src/relace_mcp/server.py
@@ -58,9 +58,11 @@ def _configure_logging_for_stdio() -> None:
 
 def check_health(config: "RelaceConfig") -> dict[str, str]:
     from .config import settings as _settings
+    from .config.indexing import resolve_index_runtime
 
     results: dict[str, str] = {}
     errors: list[str] = []
+    index_runtime = resolve_index_runtime(base_dir=config.base_dir)
 
     # base_dir is optional; if not set, it will be resolved from MCP Roots at runtime
     if config.base_dir:
@@ -115,27 +117,21 @@ def check_health(config: "RelaceConfig") -> dict[str, str]:
             errors.append(f"cannot create trace directory: {exc}")
 
     # Retrieval backend health check (passive only: do NOT run expensive CLI probes on startup)
-    if _settings.AGENTIC_RETRIEVAL_ENABLED and _settings.RETRIEVAL_BACKEND in (
-        "chunkhound",
-        "codanna",
-    ):
-        cli_path = shutil.which(_settings.RETRIEVAL_BACKEND)
+    if _settings.AGENTIC_RETRIEVAL_ENABLED and index_runtime.local_backend_enabled:
+        backend = index_runtime.active_backend
+        cli_path = shutil.which(backend)
         if not cli_path:
             logger.warning(
                 "%s backend: CLI not found in PATH — retrieval will be unavailable until installed",
-                _settings.RETRIEVAL_BACKEND,
+                backend,
             )
-            results["retrieval_backend"] = f"{_settings.RETRIEVAL_BACKEND}: cli_not_found"
+            results["retrieval_backend"] = f"{backend}: cli_not_found"
         elif not config.base_dir:
-            results["retrieval_backend"] = (
-                f"{_settings.RETRIEVAL_BACKEND}: deferred (base_dir not set)"
-            )
+            results["retrieval_backend"] = f"{backend}: deferred (base_dir not set)"
         else:
-            results["retrieval_backend"] = f"{_settings.RETRIEVAL_BACKEND}: cli_found"
-    elif _settings.AGENTIC_RETRIEVAL_ENABLED and _settings.RETRIEVAL_BACKEND == "auto":
-        results["retrieval_backend"] = "auto: deferred (resolved at query time)"
+            results["retrieval_backend"] = f"{backend}: cli_found"
     else:
-        results["retrieval_backend"] = f"{_settings.RETRIEVAL_BACKEND}: ok"
+        results["retrieval_backend"] = f"{index_runtime.active_backend}: ok"
 
     if errors:
         raise RuntimeError("; ".join(errors))
@@ -154,6 +150,7 @@ def build_server(
     from fastmcp import FastMCP
 
     from .config.bootstrap import initialize_runtime_from_env
+    from .config.indexing import resolve_index_runtime, validate_index_settings
     from .repo.monitor import BackgroundIndexMonitor
 
     if initialize_runtime:
@@ -170,6 +167,9 @@ def build_server(
     if config is None:
         config = RelaceConfig.from_env()
 
+    validate_index_settings(api_key=config.api_key)
+    index_runtime = resolve_index_runtime(base_dir=config.base_dir)
+
     if run_health_check:
         try:
             results = check_health(config)
@@ -178,16 +178,17 @@ def build_server(
             logger.error("Health check failed: %s", exc)
             raise
 
-    background_index_monitor = BackgroundIndexMonitor(config)
+    background_index_monitor = BackgroundIndexMonitor(config, index_runtime=index_runtime)
     mcp = FastMCP("Relace Fast Apply MCP", lifespan=background_index_monitor.lifespan)
     mcp._relace_background_index_monitor = background_index_monitor  # type: ignore[attr-defined]
+    mcp._relace_index_runtime = index_runtime  # type: ignore[attr-defined]
 
     # Register middleware to handle MCP notifications (e.g., roots/list_changed)
     mcp.add_middleware(RootsMiddleware())
     mcp.add_middleware(ProgressHeartbeatMiddleware())
     mcp.add_middleware(ToolTracingMiddleware())
 
-    register_tools(mcp, config)
+    register_tools(mcp, config, index_runtime)
     return mcp
 
 
@@ -225,6 +226,7 @@ def main() -> None:
     from .config import RelaceConfig
     from .config import settings as _settings
     from .config.bootstrap import initialize_runtime_from_env
+    from .config.indexing import resolve_index_runtime
     from .observability import log_event
 
     initialize_runtime_from_env()
@@ -249,6 +251,7 @@ def main() -> None:
         )
 
     config = RelaceConfig.from_env()
+    index_runtime = resolve_index_runtime(base_dir=config.base_dir)
     try:
         server_start_event: dict[str, object] = {
             "kind": "server_start",
@@ -259,11 +262,9 @@ def main() -> None:
             "mcp_trace_enabled": _settings.MCP_TRACE_LOGGING,
             "log_path": str(_settings.LOG_PATH),
             "trace_path": str(_settings.TRACE_PATH),
-            "relace_cloud_tools": _settings.RELACE_CLOUD_TOOLS,
+            "cloud_tools_enabled": index_runtime.cloud_tools_enabled,
             "mcp_search_retrieval": _settings.AGENTIC_RETRIEVAL_ENABLED,
-            "mcp_retrieval_backend": _settings.RETRIEVAL_BACKEND,
-            "codanna_cli_found": bool(shutil.which("codanna")),
-            "chunkhound_cli_found": bool(shutil.which("chunkhound")),
+            "mcp_retrieval_backend": index_runtime.active_backend,
             "base_dir": config.base_dir,
         }
 

--- a/src/relace_mcp/server.py
+++ b/src/relace_mcp/server.py
@@ -150,7 +150,7 @@ def build_server(
     from fastmcp import FastMCP
 
     from .config.bootstrap import initialize_runtime_from_env
-    from .config.indexing import resolve_index_runtime, validate_index_settings
+    from .config.indexing import resolve_index_runtime
     from .repo.monitor import BackgroundIndexMonitor
 
     if initialize_runtime:
@@ -166,8 +166,6 @@ def build_server(
 
     if config is None:
         config = RelaceConfig.from_env()
-
-    validate_index_settings(api_key=config.api_key)
     index_runtime = resolve_index_runtime(base_dir=config.base_dir)
 
     if run_health_check:
@@ -226,7 +224,6 @@ def main() -> None:
     from .config import RelaceConfig
     from .config import settings as _settings
     from .config.bootstrap import initialize_runtime_from_env
-    from .config.indexing import resolve_index_runtime
     from .observability import log_event
 
     initialize_runtime_from_env()
@@ -251,7 +248,8 @@ def main() -> None:
         )
 
     config = RelaceConfig.from_env()
-    index_runtime = resolve_index_runtime(base_dir=config.base_dir)
+    server = build_server(config, initialize_runtime=False)
+    index_runtime = server._relace_index_runtime  # type: ignore[attr-defined]
     try:
         server_start_event: dict[str, object] = {
             "kind": "server_start",
@@ -272,7 +270,6 @@ def main() -> None:
     except Exception:
         # Startup logging must never break MCP stdio transport.
         logger.debug("Failed to write server_start event", exc_info=True)
-    server = build_server(config, initialize_runtime=False)
 
     if args.transport in ("http", "streamable-http"):
         logger.debug(

--- a/src/relace_mcp/tools/_registry.py
+++ b/src/relace_mcp/tools/_registry.py
@@ -8,7 +8,7 @@ from ._setup import EncodingState, ensure_encoding_detected
 if TYPE_CHECKING:
     from fastmcp.server.context import Context
 
-    from ..config import RelaceConfig
+    from ..config import IndexRuntime, RelaceConfig
 
 
 def read_text_safe(path: Path) -> str | None:
@@ -27,6 +27,7 @@ def read_text_safe(path: Path) -> str | None:
 @dataclass(slots=True)
 class ToolRegistryDeps:
     config: "RelaceConfig"
+    index_runtime: "IndexRuntime"
     clients: ToolClients
     encoding_state: EncodingState
 

--- a/src/relace_mcp/tools/mcp_search.py
+++ b/src/relace_mcp/tools/mcp_search.py
@@ -87,16 +87,17 @@ def register_search_tools(mcp: FastMCP, deps: ToolRegistryDeps) -> None:
         await ctx.debug(f"Search found {files_found} files")
         return result
 
+    retrieval_read_only = deps.index_runtime.active_backend in ("relace", "none")
+
     if _settings.AGENTIC_RETRIEVAL_ENABLED:
 
         @mcp.tool(
             timeout=900.0,
             annotations={
-                "readOnlyHint": False,
+                "readOnlyHint": retrieval_read_only,
                 "destructiveHint": False,
                 "idempotentHint": True,
-                "openWorldHint": _settings.RETRIEVAL_BACKEND in ("relace", "auto")
-                and _settings.RELACE_CLOUD_TOOLS,
+                "openWorldHint": deps.index_runtime.cloud_tools_enabled,
             },
         )
         async def agentic_retrieval(

--- a/src/relace_mcp/tools/mcp_status.py
+++ b/src/relace_mcp/tools/mcp_status.py
@@ -1,6 +1,6 @@
 # pyright: reportUnusedFunction=false
 import shutil
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from fastmcp import FastMCP
 from fastmcp.server.context import Context
@@ -231,7 +231,9 @@ def register_status_tools(mcp: FastMCP, deps: ToolRegistryDeps) -> None:
                 "error": str(exc),
             }
 
-        active_backend = cast(ActiveBackend, deps.index_runtime.active_backend)
+        active_backend = deps.index_runtime.active_backend
+        if active_backend == "none":
+            raise RuntimeError("index_status is unavailable when MCP_RETRIEVAL_BACKEND=none")
         background_monitor = BackgroundMonitorSummary.model_validate(
             get_background_index_monitor_summary(mcp)
         )

--- a/src/relace_mcp/tools/mcp_status.py
+++ b/src/relace_mcp/tools/mcp_status.py
@@ -7,10 +7,16 @@ from fastmcp.server.context import Context
 from pydantic import BaseModel, ConfigDict, Field
 
 from ..config import resolve_base_dir
+from ..config import settings as _settings
 from ..observability import get_trace_id, log_event, redact_value
+from ..repo.backends import is_backend_disabled
 from ..repo.core import get_current_git_info, is_git_dirty
 from ..repo.core.state import load_sync_state
-from ..repo.freshness import classify_cloud_index_freshness, classify_local_index_freshness
+from ..repo.freshness import (
+    classify_cloud_index_freshness,
+    classify_local_index_freshness,
+    semantic_hints_usable_for_policy,
+)
 from ..repo.monitor import get_background_index_monitor_summary
 from ._registry import ToolRegistryDeps
 
@@ -124,7 +130,10 @@ def _build_relace_status(base_dir: str) -> RelaceBackendStatus:
             git_dirty=git_dirty,
         ),
         freshness=relace_freshness.freshness,
-        hints_usable=relace_freshness.hints_usable,
+        hints_usable=semantic_hints_usable_for_policy(
+            relace_freshness.freshness,
+            _settings.RETRIEVAL_HINT_POLICY,
+        ),
         sync_state=None,
         status=None,
     )
@@ -180,11 +189,19 @@ def _build_relace_status(base_dir: str) -> RelaceBackendStatus:
 def _build_local_backend_status(base_dir: str, backend_name: str) -> LocalBackendStatus:
     cli_path = shutil.which(backend_name)
     freshness = classify_local_index_freshness(base_dir, backend_name)
+    hints_usable = bool(
+        cli_path
+        and not is_backend_disabled(backend_name)
+        and semantic_hints_usable_for_policy(
+            freshness.freshness,
+            _settings.RETRIEVAL_HINT_POLICY,
+        )
+    )
 
     return LocalBackendStatus(
         cli_path=cli_path,
         freshness=freshness.freshness,
-        hints_usable=freshness.hints_usable if cli_path else False,
+        hints_usable=hints_usable,
     )
 
 

--- a/src/relace_mcp/tools/mcp_status.py
+++ b/src/relace_mcp/tools/mcp_status.py
@@ -1,20 +1,17 @@
 # pyright: reportUnusedFunction=false
 import shutil
-from pathlib import Path
 from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.server.context import Context
 
 from ..config import resolve_base_dir
-from ..config import settings as _settings
 from ..observability import get_trace_id, log_event, redact_value
-from ..repo.backends import schedule_bg_chunkhound_index, schedule_bg_codanna_full_index
 from ..repo.core import get_current_git_info, is_git_dirty
 from ..repo.core.state import load_sync_state
 from ..repo.freshness import classify_cloud_index_freshness, classify_local_index_freshness
 from ..repo.monitor import get_background_index_monitor_summary
-from ._registry import ToolRegistryDeps, read_text_safe
+from ._registry import ToolRegistryDeps
 
 
 def _build_relace_status(base_dir: str) -> dict[str, Any]:
@@ -24,7 +21,6 @@ def _build_relace_status(base_dir: str) -> dict[str, Any]:
 
     relace_freshness = classify_cloud_index_freshness(base_dir)
     relace_status: dict[str, Any] = {
-        "cloud_tools_enabled": _settings.RELACE_CLOUD_TOOLS,
         "local_git": {
             "git_branch": current_branch,
             "git_head": current_head[:8] if current_head else "",
@@ -84,75 +80,23 @@ def _build_relace_status(base_dir: str) -> dict[str, Any]:
     return relace_status
 
 
-def _build_local_backend_status(base_dir: str, backend_name: str) -> tuple[dict[str, Any], Any]:
-    base_path = Path(base_dir)
+def _build_local_backend_status(base_dir: str, backend_name: str) -> dict[str, Any]:
     cli_path = shutil.which(backend_name)
     freshness = classify_local_index_freshness(base_dir, backend_name)
-    head_path = base_path / f".{backend_name}" / "last_indexed_head"
-    if backend_name == "codanna":
-        index_dir_exists = (base_path / ".codanna").is_dir()
-    else:
-        index_dir_exists = (base_path / ".chunkhound").is_dir()
 
     status_obj: dict[str, Any] = {
-        "cli_found": bool(cli_path),
         "cli_path": cli_path,
-        "index_dir_exists": index_dir_exists,
-        "last_indexed_head": read_text_safe(head_path),
         "freshness": freshness.freshness,
-        "hints_usable": freshness.hints_usable,
-        "background_refresh_scheduled": False,
+        "hints_usable": freshness.hints_usable if cli_path else False,
     }
-    return status_obj, freshness
-
-
-def collect_index_status_payload(
-    base_dir: str,
-    base_dir_source: str,
-    *,
-    retrieval_backend: str,
-    schedule_local_refresh: bool,
-    background_monitor: dict[str, Any],
-) -> dict[str, Any]:
-    relace_status = _build_relace_status(base_dir)
-    codanna_status, codanna_freshness = _build_local_backend_status(base_dir, "codanna")
-    chunkhound_status, chunkhound_freshness = _build_local_backend_status(base_dir, "chunkhound")
-
-    if schedule_local_refresh:
-        for backend_name, status_obj, freshness_obj in (
-            ("codanna", codanna_status, codanna_freshness),
-            ("chunkhound", chunkhound_status, chunkhound_freshness),
-        ):
-            if not status_obj["cli_found"]:
-                status_obj["hints_usable"] = False
-                continue
-            if freshness_obj.refresh_recommended:
-                if backend_name == "codanna":
-                    schedule_bg_codanna_full_index(base_dir)
-                else:
-                    schedule_bg_chunkhound_index(base_dir)
-                status_obj["background_refresh_scheduled"] = True
-    else:
-        for status_obj in (codanna_status, chunkhound_status):
-            if not status_obj["cli_found"]:
-                status_obj["hints_usable"] = False
-
-    return {
-        "base_dir": base_dir,
-        "base_dir_source": base_dir_source,
-        "retrieval_backend": retrieval_backend,
-        "background_monitor": background_monitor,
-        "relace": relace_status,
-        "codanna": codanna_status,
-        "chunkhound": chunkhound_status,
-    }
+    return status_obj
 
 
 def register_status_tools(mcp: FastMCP, deps: ToolRegistryDeps) -> None:
     @mcp.tool(
         timeout=120.0,
         annotations={
-            "readOnlyHint": False,
+            "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
             "openWorldHint": False,
@@ -161,22 +105,10 @@ def register_status_tools(mcp: FastMCP, deps: ToolRegistryDeps) -> None:
     async def index_status(
         ctx: Context | None = None,
     ) -> dict[str, Any]:
-        """Inspect indexing services status. Call before retrieval when hints seem stale or missing,
-        or after index errors to check backend health.
+        """Inspect the active indexing backend status without mutating index state.
 
-        Single status entry point for all backends (Relace cloud, Codanna, ChunkHound).
-        Reports freshness, hints_usable, and recommended_action for each backend.
-
-        Side-effect: for local backends (Codanna/ChunkHound), automatically schedules
-        a background reindex if the index is stale or missing AND the CLI is available,
-        setting background_refresh_scheduled=true in the response.
-
-        Return structure (top-level keys):
-          relace     → {freshness, hints_usable, status.recommended_action, ...}
-          codanna    → {freshness, hints_usable, background_refresh_scheduled, ...}
-          chunkhound → {freshness, hints_usable, background_refresh_scheduled, ...}
-
-        For Relace cloud: read-only; if stale, call cloud_sync().
+        Returns a single active backend summary plus background monitor state when applicable.
+        For Relace cloud, use cloud_sync() to refresh the index when stale.
         """
         trace_id = get_trace_id()
 
@@ -188,79 +120,44 @@ def register_status_tools(mcp: FastMCP, deps: ToolRegistryDeps) -> None:
                     "kind": "index_status_error",
                     "level": "error",
                     "trace_id": trace_id,
+                    "active_backend": deps.index_runtime.active_backend,
                     "error": redact_value(str(exc), 500),
                 }
             )
             return {
                 "trace_id": trace_id,
+                "active_backend": deps.index_runtime.active_backend,
                 "base_dir": None,
                 "error": str(exc),
             }
 
-        status_payload: dict[str, Any] = collect_index_status_payload(
-            base_dir,
-            base_dir_source,
-            retrieval_backend=_settings.RETRIEVAL_BACKEND,
-            schedule_local_refresh=True,
-            background_monitor=get_background_index_monitor_summary(mcp),
-        )
+        active_backend = deps.index_runtime.active_backend
+        if active_backend == "relace":
+            backend_status = _build_relace_status(base_dir)
+        else:
+            backend_status = _build_local_backend_status(base_dir, active_backend)
+
         payload: dict[str, Any] = {
             "trace_id": trace_id,
-            **status_payload,
+            "base_dir": base_dir,
+            "base_dir_source": base_dir_source,
+            "active_backend": active_backend,
+            "backend": backend_status,
+            "background_monitor": get_background_index_monitor_summary(mcp),
         }
-
-        relace_status = status_payload["relace"]
-        codanna_status = status_payload["codanna"]
-        chunkhound_status = status_payload["chunkhound"]
-
-        if not isinstance(relace_status, dict):
-            relace_status = {}
-        if not isinstance(codanna_status, dict):
-            codanna_status = {}
-        if not isinstance(chunkhound_status, dict):
-            chunkhound_status = {}
-
-        relace_needs_sync = None
-        relace_recommended_action = None
-        relace_status_detail = relace_status.get("status")
-        if isinstance(relace_status_detail, dict):
-            relace_needs_sync = relace_status_detail.get("needs_sync")
-            relace_recommended_action = relace_status_detail.get("recommended_action")
 
         log_event(
             {
                 "kind": "index_status",
                 "level": "info",
                 "trace_id": trace_id,
+                "active_backend": active_backend,
                 "base_dir": base_dir,
                 "base_dir_source": base_dir_source,
-                "retrieval_backend": _settings.RETRIEVAL_BACKEND,
-                "relace_cloud_tools_enabled": bool(relace_status.get("cloud_tools_enabled")),
-                "relace_freshness": relace_status.get("freshness"),
-                "relace_hints_usable": relace_status.get("hints_usable"),
-                "relace_needs_sync": relace_needs_sync,
-                "relace_recommended_action": redact_value(
-                    str(relace_recommended_action),
-                    500,
-                )
-                if relace_recommended_action
-                else None,
-                "codanna_cli_found": bool(codanna_status.get("cli_found")),
-                "codanna_index_dir_exists": bool(codanna_status.get("index_dir_exists")),
-                "codanna_last_indexed_head": codanna_status.get("last_indexed_head"),
-                "codanna_freshness": codanna_status.get("freshness"),
-                "codanna_hints_usable": codanna_status.get("hints_usable"),
-                "codanna_background_refresh_scheduled": codanna_status.get(
-                    "background_refresh_scheduled"
-                ),
-                "chunkhound_cli_found": bool(chunkhound_status.get("cli_found")),
-                "chunkhound_index_dir_exists": bool(chunkhound_status.get("index_dir_exists")),
-                "chunkhound_last_indexed_head": chunkhound_status.get("last_indexed_head"),
-                "chunkhound_freshness": chunkhound_status.get("freshness"),
-                "chunkhound_hints_usable": chunkhound_status.get("hints_usable"),
-                "chunkhound_background_refresh_scheduled": chunkhound_status.get(
-                    "background_refresh_scheduled"
-                ),
+                "backend_freshness": backend_status.get("freshness"),
+                "backend_hints_usable": backend_status.get("hints_usable"),
+                "background_monitor_enabled": payload["background_monitor"].get("enabled"),
+                "background_monitor_reason": payload["background_monitor"].get("reason"),
             }
         )
 

--- a/src/relace_mcp/tools/mcp_status.py
+++ b/src/relace_mcp/tools/mcp_status.py
@@ -1,9 +1,10 @@
 # pyright: reportUnusedFunction=false
 import shutil
-from typing import Any
+from typing import Any, Literal, cast
 
 from fastmcp import FastMCP
 from fastmcp.server.context import Context
+from pydantic import BaseModel, ConfigDict, Field
 
 from ..config import resolve_base_dir
 from ..observability import get_trace_id, log_event, redact_value
@@ -14,45 +15,141 @@ from ..repo.monitor import get_background_index_monitor_summary
 from ._registry import ToolRegistryDeps
 
 
-def _build_relace_status(base_dir: str) -> dict[str, Any]:
+class _StatusModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class BackgroundMonitorSummary(_StatusModel):
+    state: str = Field(description="Current background monitor state.")
+    reason: str | None = Field(description="Reason for the current monitor state, if any.")
+    interval_seconds: float | None = Field(
+        description="Configured monitor interval in seconds when the monitor is requested."
+    )
+    initial_delay_seconds: float | None = Field(
+        description="Configured startup delay in seconds when the monitor is requested."
+    )
+
+
+class LocalGitStatus(_StatusModel):
+    git_branch: str = Field(description="Current local git branch.")
+    git_head: str = Field(description="Current local git HEAD, shortened to 8 characters.")
+    git_dirty: bool = Field(description="Whether the local working tree has uncommitted changes.")
+
+
+class RelaceSyncState(_StatusModel):
+    repo_id: str = Field(description="Relace Cloud repository ID from the last successful sync.")
+    repo_head: str = Field(description="Cloud repository HEAD, shortened to 8 characters.")
+    git_branch: str = Field(description="Git branch recorded at the last sync.")
+    git_head: str = Field(
+        description="Git HEAD recorded at the last sync, shortened to 8 characters."
+    )
+    last_sync: str = Field(description="Timestamp of the last successful sync.")
+    tracked_files: int = Field(description="Number of tracked files included in sync state.")
+    skipped_files: int = Field(description="Number of files skipped during the last sync.")
+    files_found: int = Field(description="Number of files discovered before sync filtering.")
+    files_selected: int = Field(description="Number of files selected for sync.")
+    file_limit: int = Field(description="Configured file selection limit for sync.")
+    files_truncated: int = Field(
+        description="Number of files omitted because sync hit the configured file limit."
+    )
+
+
+class RelaceSyncStatus(_StatusModel):
+    ref_changed: bool = Field(description="Whether git HEAD changed since the last cloud sync.")
+    needs_sync: bool = Field(description="Whether the cloud index should be refreshed.")
+    recommended_action: str | None = Field(
+        description="Suggested next action when the cloud index is stale or missing."
+    )
+
+
+class RelaceBackendStatus(_StatusModel):
+    local_git: LocalGitStatus = Field(description="Current local git state for the workspace.")
+    freshness: str = Field(description="Freshness classification for the Relace cloud index.")
+    hints_usable: bool = Field(description="Whether semantic hints are safe to use right now.")
+    sync_state: RelaceSyncState | None = Field(
+        description="Last known cloud sync metadata, or null when no sync has been recorded."
+    )
+    status: RelaceSyncStatus | None = Field(
+        description="Sync recommendation details, or null when no extra action is needed."
+    )
+
+
+class LocalBackendStatus(_StatusModel):
+    cli_path: str | None = Field(
+        description="Resolved CLI path for the active local backend, or null when not installed."
+    )
+    freshness: str = Field(description="Freshness classification for the active local index.")
+    hints_usable: bool = Field(
+        description="Whether semantic hints are usable for the active backend."
+    )
+
+
+ActiveBackend = Literal["relace", "codanna", "chunkhound"]
+
+
+class IndexStatusToolOutput(_StatusModel):
+    trace_id: str = Field(description="Trace ID for correlating logs for this tool call.")
+    active_backend: ActiveBackend = Field(description="The configured active indexing backend.")
+    base_dir: str | None = Field(
+        default=None, description="Resolved repository base directory, if available."
+    )
+    base_dir_source: str | None = Field(
+        default=None,
+        description="How the base directory was resolved, when resolution succeeded.",
+    )
+    backend: RelaceBackendStatus | LocalBackendStatus | None = Field(
+        default=None,
+        description="Status summary for the active backend, when inspection succeeded.",
+    )
+    background_monitor: BackgroundMonitorSummary | None = Field(
+        default=None,
+        description="Background monitor state summary, when inspection succeeded.",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Error message explaining why status inspection failed.",
+    )
+
+
+def _build_relace_status(base_dir: str) -> RelaceBackendStatus:
     current_branch, current_head = get_current_git_info(base_dir)
     git_dirty = is_git_dirty(base_dir)
     sync_state = load_sync_state(base_dir)
 
     relace_freshness = classify_cloud_index_freshness(base_dir)
-    relace_status: dict[str, Any] = {
-        "local_git": {
-            "git_branch": current_branch,
-            "git_head": current_head[:8] if current_head else "",
-            "git_dirty": git_dirty,
-        },
-        "freshness": relace_freshness.freshness,
-        "hints_usable": relace_freshness.hints_usable,
-        "sync_state": None,
-        "status": None,
-    }
+    relace_status = RelaceBackendStatus(
+        local_git=LocalGitStatus(
+            git_branch=current_branch,
+            git_head=current_head[:8] if current_head else "",
+            git_dirty=git_dirty,
+        ),
+        freshness=relace_freshness.freshness,
+        hints_usable=relace_freshness.hints_usable,
+        sync_state=None,
+        status=None,
+    )
 
     if sync_state is None:
-        relace_status["status"] = {
-            "ref_changed": False,
-            "needs_sync": True,
-            "recommended_action": "No sync state found. Run cloud_sync().",
-        }
+        relace_status.status = RelaceSyncStatus(
+            ref_changed=False,
+            needs_sync=True,
+            recommended_action="No sync state found. Run cloud_sync().",
+        )
         return relace_status
 
-    relace_status["sync_state"] = {
-        "repo_id": sync_state.repo_id,
-        "repo_head": sync_state.repo_head[:8] if sync_state.repo_head else "",
-        "git_branch": sync_state.git_branch,
-        "git_head": sync_state.git_head_sha[:8] if sync_state.git_head_sha else "",
-        "last_sync": sync_state.last_sync,
-        "tracked_files": len(sync_state.files),
-        "skipped_files": len(sync_state.skipped_files),
-        "files_found": sync_state.files_found,
-        "files_selected": sync_state.files_selected,
-        "file_limit": sync_state.file_limit,
-        "files_truncated": sync_state.files_truncated,
-    }
+    relace_status.sync_state = RelaceSyncState(
+        repo_id=sync_state.repo_id,
+        repo_head=sync_state.repo_head[:8] if sync_state.repo_head else "",
+        git_branch=sync_state.git_branch,
+        git_head=sync_state.git_head_sha[:8] if sync_state.git_head_sha else "",
+        last_sync=sync_state.last_sync,
+        tracked_files=len(sync_state.files),
+        skipped_files=len(sync_state.skipped_files),
+        files_found=sync_state.files_found,
+        files_selected=sync_state.files_selected,
+        file_limit=sync_state.file_limit,
+        files_truncated=sync_state.files_truncated,
+    )
 
     ref_changed = False
     needs_sync = False
@@ -72,28 +169,28 @@ def _build_relace_status(base_dir: str) -> dict[str, Any]:
             "to reflect uncommitted changes."
         )
 
-    relace_status["status"] = {
-        "ref_changed": ref_changed,
-        "needs_sync": needs_sync,
-        "recommended_action": recommended_action,
-    }
+    relace_status.status = RelaceSyncStatus(
+        ref_changed=ref_changed,
+        needs_sync=needs_sync,
+        recommended_action=recommended_action,
+    )
     return relace_status
 
 
-def _build_local_backend_status(base_dir: str, backend_name: str) -> dict[str, Any]:
+def _build_local_backend_status(base_dir: str, backend_name: str) -> LocalBackendStatus:
     cli_path = shutil.which(backend_name)
     freshness = classify_local_index_freshness(base_dir, backend_name)
 
-    status_obj: dict[str, Any] = {
-        "cli_path": cli_path,
-        "freshness": freshness.freshness,
-        "hints_usable": freshness.hints_usable if cli_path else False,
-    }
-    return status_obj
+    return LocalBackendStatus(
+        cli_path=cli_path,
+        freshness=freshness.freshness,
+        hints_usable=freshness.hints_usable if cli_path else False,
+    )
 
 
 def register_status_tools(mcp: FastMCP, deps: ToolRegistryDeps) -> None:
     @mcp.tool(
+        output_schema=IndexStatusToolOutput.model_json_schema(),
         timeout=120.0,
         annotations={
             "readOnlyHint": True,
@@ -105,10 +202,13 @@ def register_status_tools(mcp: FastMCP, deps: ToolRegistryDeps) -> None:
     async def index_status(
         ctx: Context | None = None,
     ) -> dict[str, Any]:
-        """Inspect the active indexing backend status without mutating index state.
+        """Inspect the single active indexing backend in read-only mode.
 
-        Returns a single active backend summary plus background monitor state when applicable.
-        For Relace cloud, use cloud_sync() to refresh the index when stale.
+        Use this before retrieval when you need to know whether the active backend is fresh and
+        whether semantic hints are usable. Returns `active_backend`, a single `backend` status
+        object with `freshness` and `hints_usable`, and `background_monitor` (`state`, `reason`).
+        This tool never refreshes indexes; if `active_backend` is `relace` and
+        `backend.status.needs_sync` is true, run cloud_sync().
         """
         trace_id = get_trace_id()
 
@@ -131,20 +231,32 @@ def register_status_tools(mcp: FastMCP, deps: ToolRegistryDeps) -> None:
                 "error": str(exc),
             }
 
-        active_backend = deps.index_runtime.active_backend
+        active_backend = cast(ActiveBackend, deps.index_runtime.active_backend)
+        background_monitor = BackgroundMonitorSummary.model_validate(
+            get_background_index_monitor_summary(mcp)
+        )
+        backend_status: RelaceBackendStatus | LocalBackendStatus
         if active_backend == "relace":
             backend_status = _build_relace_status(base_dir)
+            payload = IndexStatusToolOutput(
+                trace_id=trace_id,
+                base_dir=base_dir,
+                base_dir_source=base_dir_source,
+                active_backend=active_backend,
+                backend=backend_status,
+                background_monitor=background_monitor,
+            )
         else:
-            backend_status = _build_local_backend_status(base_dir, active_backend)
-
-        payload: dict[str, Any] = {
-            "trace_id": trace_id,
-            "base_dir": base_dir,
-            "base_dir_source": base_dir_source,
-            "active_backend": active_backend,
-            "backend": backend_status,
-            "background_monitor": get_background_index_monitor_summary(mcp),
-        }
+            local_backend = active_backend
+            backend_status = _build_local_backend_status(base_dir, local_backend)
+            payload = IndexStatusToolOutput(
+                trace_id=trace_id,
+                base_dir=base_dir,
+                base_dir_source=base_dir_source,
+                active_backend=local_backend,
+                backend=backend_status,
+                background_monitor=background_monitor,
+            )
 
         log_event(
             {
@@ -154,11 +266,11 @@ def register_status_tools(mcp: FastMCP, deps: ToolRegistryDeps) -> None:
                 "active_backend": active_backend,
                 "base_dir": base_dir,
                 "base_dir_source": base_dir_source,
-                "backend_freshness": backend_status.get("freshness"),
-                "backend_hints_usable": backend_status.get("hints_usable"),
-                "background_monitor_enabled": payload["background_monitor"].get("enabled"),
-                "background_monitor_reason": payload["background_monitor"].get("reason"),
+                "backend_freshness": backend_status.freshness,
+                "backend_hints_usable": backend_status.hints_usable,
+                "background_monitor_enabled": background_monitor.state == "active",
+                "background_monitor_reason": background_monitor.reason,
             }
         )
 
-        return payload
+        return payload.model_dump(mode="json", exclude={"error"})

--- a/src/relace_mcp/tools/register.py
+++ b/src/relace_mcp/tools/register.py
@@ -1,11 +1,8 @@
 # pyright: reportUnusedFunction=false
 # Decorator-registered functions (@mcp.tool, @mcp.resource) are accessed by the framework
-import shutil
-
 from fastmcp import FastMCP
 
-from ..config import RelaceConfig
-from ..config import settings as _settings
+from ..config import IndexRuntime, RelaceConfig
 from ._clients import ToolClients
 from ._registry import ToolRegistryDeps
 from ._setup import EncodingState
@@ -17,23 +14,18 @@ from .mcp_status import register_status_tools
 __all__ = ["register_tools"]
 
 
-def _should_register_index_status() -> bool:
-    return _settings.RELACE_CLOUD_TOOLS or any(
-        shutil.which(name) for name in ("codanna", "chunkhound")
-    )
-
-
-def register_tools(mcp: FastMCP, config: RelaceConfig) -> None:
+def register_tools(mcp: FastMCP, config: RelaceConfig, index_runtime: IndexRuntime) -> None:
     """Register Relace tools to the FastMCP instance."""
     deps = ToolRegistryDeps(
         config=config,
+        index_runtime=index_runtime,
         clients=ToolClients(config),
         encoding_state=EncodingState(),
     )
 
     register_apply_tools(mcp, deps)
     register_search_tools(mcp, deps)
-    if _should_register_index_status():
+    if index_runtime.index_status_enabled:
         register_status_tools(mcp, deps)
-    if _settings.RELACE_CLOUD_TOOLS:
+    if index_runtime.cloud_tools_enabled:
         register_cloud_components(mcp, deps)

--- a/tests/config/test_base_dir_unit.py
+++ b/tests/config/test_base_dir_unit.py
@@ -360,6 +360,54 @@ class TestResolveBaseDir:
         assert "Git root" in source
 
     @pytest.mark.asyncio
+    async def test_single_blacklisted_mcp_root_falls_back_to_git_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Blacklisted MCP Root should be ignored."""
+        import relace_mcp.config.base_dir as base_dir_module
+
+        monkeypatch.setattr(base_dir_module, "resolve_workspace_from_storage", lambda: None)
+
+        (tmp_path / ".git").mkdir()
+        cwd = tmp_path / "src"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+
+        blocked_root = Path.home() / ".codeium" / "windsurf"
+        ctx = MagicMock()
+        ctx.list_roots = AsyncMock(
+            return_value=[MagicMock(uri=blocked_root.as_uri(), name="windsurf")]
+        )
+
+        base_dir, source = await resolve_base_dir(None, ctx)
+        assert base_dir == str(tmp_path)
+        assert "Git root" in source
+
+    @pytest.mark.asyncio
+    async def test_blacklisted_cached_mcp_root_falls_back_to_git_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Blacklisted cached MCP Root should be ignored."""
+        import relace_mcp.config.base_dir as base_dir_module
+
+        monkeypatch.setattr(base_dir_module, "resolve_workspace_from_storage", lambda: None)
+
+        (tmp_path / ".git").mkdir()
+        cwd = tmp_path / "src"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+
+        blocked_root = str(Path.home() / ".codeium" / "windsurf")
+        base_dir_module._roots_cache = {"session-1": (blocked_root, "MCP Root (windsurf)")}
+
+        ctx = MagicMock(session_id="session-1")
+        ctx.list_roots = AsyncMock(return_value=[])
+
+        base_dir, source = await resolve_base_dir(None, ctx)
+        assert base_dir == str(tmp_path)
+        assert "Git root" in source
+
+    @pytest.mark.asyncio
     async def test_multiple_invalid_mcp_roots_falls_back_to_git_root(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/config/test_base_dir_unit.py
+++ b/tests/config/test_base_dir_unit.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -202,6 +203,21 @@ class TestSelectBestRoot:
 
 
 class TestResolveBaseDir:
+    def test_blocked_mcp_roots_are_resolved(self, tmp_path: Path, monkeypatch) -> None:
+        import relace_mcp.config.base_dir as base_dir_module
+
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
+        symlink_home = tmp_path / "symlink-home"
+        symlink_home.symlink_to(real_home, target_is_directory=True)
+
+        with monkeypatch.context() as scoped:
+            scoped.setattr(Path, "home", classmethod(lambda cls: symlink_home))
+            reloaded = importlib.reload(base_dir_module)
+            assert reloaded._BLOCKED_MCP_ROOTS == ((real_home / ".codeium" / "windsurf").resolve(),)
+
+        importlib.reload(base_dir_module)
+
     @pytest.mark.asyncio
     async def test_uses_config_base_dir_when_set(self) -> None:
         """Explicit config takes highest priority."""

--- a/tests/config/test_bootstrap_unit.py
+++ b/tests/config/test_bootstrap_unit.py
@@ -7,7 +7,7 @@ import relace_mcp.config.settings as settings_mod
 from relace_mcp.config.bootstrap import initialize_runtime_from_env
 
 _SNAPSHOT_KEYS = (
-    "RELACE_CLOUD_TOOLS",
+    "RETRIEVAL_BACKEND",
     "SEARCH_MAX_TURNS",
     "MCP_LOG_LEVEL",
     "SEARCH_PROVIDER",
@@ -31,7 +31,7 @@ def test_initialize_runtime_from_env_loads_explicit_dotenv(
     env_file.write_text(
         "\n".join(
             [
-                "RELACE_CLOUD_TOOLS=1",
+                "MCP_RETRIEVAL_BACKEND=chunkhound",
                 "SEARCH_MAX_TURNS=9",
                 "MCP_LOG_LEVEL=debug",
             ]
@@ -40,14 +40,14 @@ def test_initialize_runtime_from_env_loads_explicit_dotenv(
         encoding="utf-8",
     )
 
-    monkeypatch.delenv("RELACE_CLOUD_TOOLS", raising=False)
+    monkeypatch.delenv("MCP_RETRIEVAL_BACKEND", raising=False)
     monkeypatch.delenv("SEARCH_MAX_TURNS", raising=False)
     monkeypatch.delenv("MCP_LOG_LEVEL", raising=False)
     monkeypatch.setenv("MCP_DOTENV_PATH", str(env_file))
 
     initialize_runtime_from_env()
 
-    assert settings_mod.RELACE_CLOUD_TOOLS is True
+    assert settings_mod.RETRIEVAL_BACKEND == "chunkhound"
     assert settings_mod.SEARCH_MAX_TURNS == 9
     assert settings_mod.MCP_LOG_LEVEL == "DEBUG"
 

--- a/tests/config/test_config_unit.py
+++ b/tests/config/test_config_unit.py
@@ -7,16 +7,31 @@ from relace_mcp.config import RelaceConfig
 
 class TestRelaceConfigFromEnv:
     @pytest.mark.usefixtures("clean_env")
-    def test_missing_api_key_allowed_by_default(self) -> None:
-        """When RELACE_CLOUD_TOOLS is off (default), API key is optional."""
+    def test_missing_api_key_raises_for_default_relace_backend(self) -> None:
+        """Default relace backend requires RELACE_API_KEY."""
+        with pytest.raises(RuntimeError, match="RELACE_API_KEY is required"):
+            RelaceConfig.from_env()
+
+    @pytest.mark.usefixtures("clean_env")
+    def test_missing_api_key_allowed_for_none_backend(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "none")
         config = RelaceConfig.from_env()
         assert config.api_key is None
 
     @pytest.mark.usefixtures("clean_env")
-    def test_missing_api_key_raises_with_cloud_tools(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """When RELACE_CLOUD_TOOLS is on, API key is required."""
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "1")
-        with pytest.raises(RuntimeError, match="RELACE_API_KEY is required"):
+    def test_missing_api_key_allowed_for_local_backend(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "codanna")
+        config = RelaceConfig.from_env()
+        assert config.api_key is None
+
+    @pytest.mark.usefixtures("clean_env")
+    def test_auto_backend_raises_migration_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "auto")
+        with pytest.raises(RuntimeError, match="auto is no longer supported"):
             RelaceConfig.from_env()
 
     @pytest.mark.usefixtures("clean_env")
@@ -31,7 +46,7 @@ class TestRelaceConfigBaseDir:
     @pytest.mark.usefixtures("clean_env")
     def test_missing_base_dir_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """When MCP_BASE_DIR is not set, base_dir should be None (resolved at runtime)."""
-        monkeypatch.setenv("RELACE_API_KEY", "test-key")
+        monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "none")
         config = RelaceConfig.from_env()
         assert config.base_dir is None
 

--- a/tests/config/test_reload_settings_unit.py
+++ b/tests/config/test_reload_settings_unit.py
@@ -17,7 +17,6 @@ _RELOAD_KEYS = (
 )
 
 _TOOL_RELOAD_KEYS = (
-    "RELACE_CLOUD_TOOLS",
     "RETRIEVAL_BACKEND",
     "RETRIEVAL_HINT_POLICY",
     "AGENTIC_RETRIEVAL_ENABLED",
@@ -108,29 +107,16 @@ class TestReloadLoggingSettings:
 
 
 class TestReloadToolSettings:
-    def test_cloud_tools_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "true")
-        reload_tool_settings()
-
-        assert settings_mod.RELACE_CLOUD_TOOLS is True
-
-    def test_cloud_tools_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "false")
-        reload_tool_settings()
-
-        assert settings_mod.RELACE_CLOUD_TOOLS is False
-
     def test_retrieval_backend_codanna(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "codanna")
         reload_tool_settings()
 
         assert settings_mod.RETRIEVAL_BACKEND == "codanna"
 
-    def test_retrieval_backend_auto(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_retrieval_backend_auto_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "auto")
-        reload_tool_settings()
-
-        assert settings_mod.RETRIEVAL_BACKEND == "auto"
+        with pytest.raises(RuntimeError, match="auto is no longer supported"):
+            reload_tool_settings()
 
     def test_agentic_retrieval_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MCP_SEARCH_RETRIEVAL", "true")
@@ -238,11 +224,9 @@ class TestReloadToolSettings:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Accessing settings via module reference must see reloaded values."""
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "true")
         monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "chunkhound")
         reload_tool_settings()
 
         from relace_mcp.config import settings as _settings
 
-        assert _settings.RELACE_CLOUD_TOOLS is True
         assert _settings.RETRIEVAL_BACKEND == "chunkhound"

--- a/tests/docs/test_user_docs_unit.py
+++ b/tests/docs/test_user_docs_unit.py
@@ -10,13 +10,13 @@ README_DOCS = [
 TOOLS_DOCS = [
     (
         Path("docs/tools.md"),
-        "Available only when `RELACE_CLOUD_TOOLS=1`.",
+        "Available only when `MCP_RETRIEVAL_BACKEND=relace`.",
         "Available only when `MCP_SEARCH_RETRIEVAL=1`.",
         "Search-Only Subtools",
     ),
     (
         Path("docs/tools.zh-CN.md"),
-        "仅在 `RELACE_CLOUD_TOOLS=1` 时可用。",
+        "仅在 `MCP_RETRIEVAL_BACKEND=relace` 时可用。",
         "仅在 `MCP_SEARCH_RETRIEVAL=1` 时可用。",
         "Search-Only Subtools",
     ),

--- a/tests/mcp/test_mcp_compliance_contract.py
+++ b/tests/mcp/test_mcp_compliance_contract.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -197,6 +198,41 @@ class TestMCPToolAnnotations:
         assert annotations is not None
         assert annotations.readOnlyHint is True
         assert annotations.destructiveHint is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("clean_env")
+    async def test_index_status_description_guides_refresh_flow(
+        self, mock_config: RelaceConfig
+    ) -> None:
+        server = build_server(config=mock_config, run_health_check=False)
+
+        async with Client(server) as client:
+            tools = await client.list_tools()
+            status_tool = next((tool for tool in tools if tool.name == STATUS_TOOL), None)
+
+        assert status_tool is not None
+        assert status_tool.description is not None
+        assert "Use this before retrieval" in status_tool.description
+        assert "never refreshes indexes" in status_tool.description
+        assert "cloud_sync()" in status_tool.description
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("clean_env")
+    async def test_index_status_has_specific_output_schema(self, mock_config: RelaceConfig) -> None:
+        server = build_server(config=mock_config, run_health_check=False)
+
+        async with Client(server) as client:
+            tools = await client.list_tools()
+            status_tool = next((tool for tool in tools if tool.name == STATUS_TOOL), None)
+
+        assert status_tool is not None
+        schema = getattr(status_tool, "outputSchema", None)
+        assert isinstance(schema, dict)
+        schema_json = json.dumps(schema)
+        assert '"background_monitor"' in schema_json
+        assert '"freshness"' in schema_json
+        assert '"hints_usable"' in schema_json
+        assert '"recommended_action"' in schema_json
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")

--- a/tests/mcp/test_mcp_compliance_contract.py
+++ b/tests/mcp/test_mcp_compliance_contract.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 from fastmcp import Client
@@ -7,9 +6,8 @@ from fastmcp import Client
 from relace_mcp.config import RelaceConfig
 from relace_mcp.server import build_server
 
-CORE_TOOLS = ["fast_apply", "agentic_search"]
-CLOUD_TOOLS = ["cloud_sync", "cloud_search", "cloud_clear", "cloud_list"]
-RETRIEVAL_TOOLS = ["agentic_retrieval"]
+CORE_TOOLS = {"fast_apply", "agentic_search"}
+CLOUD_TOOLS = {"cloud_sync", "cloud_search", "cloud_clear", "cloud_list"}
 STATUS_TOOL = "index_status"
 
 
@@ -18,193 +16,116 @@ def mock_config(tmp_path: Path) -> RelaceConfig:
     return RelaceConfig(api_key="rlc-contract-test", base_dir=str(tmp_path))
 
 
+async def _list_tool_names(server) -> set[str]:
+    async with Client(server) as client:
+        tools = await client.list_tools()
+        return {tool.name for tool in tools}
+
+
+async def _list_resource_uris(server) -> set[str]:
+    async with Client(server) as client:
+        resources = await client.list_resources()
+        return {str(resource.uri) for resource in resources}
+
+
 class TestMCPToolExistence:
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
     async def test_core_tools_always_registered(self, mock_config: RelaceConfig) -> None:
-        """Core tools (fast_apply, agentic_search) must always be present."""
         server = build_server(config=mock_config, run_health_check=False)
-
-        async with Client(server) as client:
-            tools = await client.list_tools()
-            tool_names = {t.name for t in tools}
-
-            for tool in CORE_TOOLS:
-                assert tool in tool_names, f"Core tool '{tool}' not registered"
+        assert CORE_TOOLS.issubset(await _list_tool_names(server))
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
-    async def test_cloud_tools_conditional_on_flag(
+    @pytest.mark.parametrize(
+        ("backend", "expected_cloud_tools", "expected_status_tool"),
+        [
+            ("relace", CLOUD_TOOLS, True),
+            ("codanna", set(), True),
+            ("chunkhound", set(), True),
+            ("none", set(), False),
+        ],
+    )
+    async def test_tool_visibility_matches_active_backend(
         self,
         mock_config: RelaceConfig,
         monkeypatch: pytest.MonkeyPatch,
+        backend: str,
+        expected_cloud_tools: set[str],
+        expected_status_tool: bool,
     ) -> None:
-        """Cloud tools must be visible when RELACE_CLOUD_TOOLS=true."""
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "1")
+        monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", backend)
         server = build_server(config=mock_config, run_health_check=False)
+        tool_names = await _list_tool_names(server)
 
-        async with Client(server) as client:
-            tools = await client.list_tools()
-            tool_names = {t.name for t in tools}
+        for tool in CLOUD_TOOLS:
+            assert (tool in tool_names) is (tool in expected_cloud_tools)
 
-            for tool in CLOUD_TOOLS:
-                assert tool in tool_names, f"Cloud tool '{tool}' not registered"
-
-    @pytest.mark.asyncio
-    @pytest.mark.usefixtures("clean_env")
-    async def test_cloud_tools_absent_when_disabled(
-        self,
-        mock_config: RelaceConfig,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Cloud tools must be hidden when RELACE_CLOUD_TOOLS=false."""
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "0")
-        server = build_server(config=mock_config, run_health_check=False)
-
-        async with Client(server) as client:
-            tools = await client.list_tools()
-            tool_names = {t.name for t in tools}
-
-            for tool in CLOUD_TOOLS:
-                assert tool not in tool_names, f"Cloud tool '{tool}' should NOT be registered"
+        assert (STATUS_TOOL in tool_names) is expected_status_tool
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
-    async def test_index_status_visible_when_cloud_tools_enabled(
+    @pytest.mark.parametrize("backend", ["relace", "codanna", "chunkhound", "none"])
+    async def test_agentic_retrieval_visibility_depends_on_flag(
         self,
         mock_config: RelaceConfig,
         monkeypatch: pytest.MonkeyPatch,
+        backend: str,
     ) -> None:
-        """index_status must be visible when cloud indexing is enabled."""
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "1")
-        with patch("relace_mcp.tools.register.shutil.which", return_value=None):
-            server = build_server(config=mock_config, run_health_check=False)
+        monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", backend)
+        server_without = build_server(config=mock_config, run_health_check=False)
+        assert "agentic_retrieval" not in await _list_tool_names(server_without)
 
-        async with Client(server) as client:
-            tools = await client.list_tools()
-            tool_names = {t.name for t in tools}
-
-        assert STATUS_TOOL in tool_names
-
-    @pytest.mark.asyncio
-    @pytest.mark.usefixtures("clean_env")
-    async def test_index_status_visible_when_codanna_cli_available(
-        self,
-        mock_config: RelaceConfig,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """index_status must be visible when codanna CLI is available."""
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "0")
-
-        def _which(name: str) -> str | None:
-            if name == "codanna":
-                return "/usr/local/bin/codanna"
-            return None
-
-        with patch("relace_mcp.tools.register.shutil.which", side_effect=_which):
-            server = build_server(config=mock_config, run_health_check=False)
-
-        async with Client(server) as client:
-            tools = await client.list_tools()
-            tool_names = {t.name for t in tools}
-
-        assert STATUS_TOOL in tool_names
-
-    @pytest.mark.asyncio
-    @pytest.mark.usefixtures("clean_env")
-    async def test_index_status_visible_when_chunkhound_cli_available(
-        self,
-        mock_config: RelaceConfig,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """index_status must be visible when chunkhound CLI is available."""
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "0")
-
-        def _which(name: str) -> str | None:
-            if name == "chunkhound":
-                return "/usr/local/bin/chunkhound"
-            return None
-
-        with patch("relace_mcp.tools.register.shutil.which", side_effect=_which):
-            server = build_server(config=mock_config, run_health_check=False)
-
-        async with Client(server) as client:
-            tools = await client.list_tools()
-            tool_names = {t.name for t in tools}
-
-        assert STATUS_TOOL in tool_names
-
-    @pytest.mark.asyncio
-    @pytest.mark.usefixtures("clean_env")
-    async def test_index_status_hidden_without_indexing_capability(
-        self,
-        mock_config: RelaceConfig,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """index_status must be hidden when no cloud or local indexing capability exists."""
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "0")
-        with patch("relace_mcp.tools.register.shutil.which", return_value=None):
-            server = build_server(config=mock_config, run_health_check=False)
-
-        async with Client(server) as client:
-            tools = await client.list_tools()
-            tool_names = {t.name for t in tools}
-
-            assert STATUS_TOOL not in tool_names
-            with pytest.raises(Exception, match="Unknown tool"):
-                await client.call_tool(STATUS_TOOL, {})
+        monkeypatch.setenv("MCP_SEARCH_RETRIEVAL", "1")
+        server_with = build_server(config=mock_config, run_health_check=False)
+        assert "agentic_retrieval" in await _list_tool_names(server_with)
 
 
 class TestMCPToolSchemas:
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
     async def test_fast_apply_has_required_params(self, mock_config: RelaceConfig) -> None:
-        """fast_apply must have path, edit_snippet, instruction parameters."""
         server = build_server(config=mock_config, run_health_check=False)
 
         async with Client(server) as client:
             tools = await client.list_tools()
-            fast_apply = next((t for t in tools if t.name == "fast_apply"), None)
+            fast_apply = next((tool for tool in tools if tool.name == "fast_apply"), None)
 
-            assert fast_apply is not None
-            schema = fast_apply.inputSchema
-            props = schema.get("properties", {})
-
-            assert "path" in props
-            assert "edit_snippet" in props
-            assert "instruction" in props
-            assert props["path"].get("type") == "string"
-            assert props["edit_snippet"].get("type") == "string"
+        assert fast_apply is not None
+        schema = fast_apply.inputSchema
+        props = schema.get("properties", {})
+        assert "path" in props
+        assert "edit_snippet" in props
+        assert "instruction" in props
+        assert props["path"].get("type") == "string"
+        assert props["edit_snippet"].get("type") == "string"
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
     async def test_agentic_search_has_query_param(self, mock_config: RelaceConfig) -> None:
-        """agentic_search must have query parameter."""
         server = build_server(config=mock_config, run_health_check=False)
 
         async with Client(server) as client:
             tools = await client.list_tools()
-            search = next((t for t in tools if t.name == "agentic_search"), None)
+            search = next((tool for tool in tools if tool.name == "agentic_search"), None)
 
-            assert search is not None
-            schema = search.inputSchema
-            props = schema.get("properties", {})
-
-            assert "query" in props
-            assert props["query"].get("type") == "string"
+        assert search is not None
+        schema = search.inputSchema
+        props = schema.get("properties", {})
+        assert "query" in props
+        assert props["query"].get("type") == "string"
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
     async def test_all_tools_have_descriptions(self, mock_config: RelaceConfig) -> None:
-        """All tools must have non-empty descriptions."""
         server = build_server(config=mock_config, run_health_check=False)
 
         async with Client(server) as client:
             tools = await client.list_tools()
 
-            for tool in tools:
-                assert tool.description, f"Tool '{tool.name}' has no description"
-                assert len(tool.description) > 10, f"Tool '{tool.name}' description too short"
+        for tool in tools:
+            assert tool.description
+            assert len(tool.description) > 10
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
@@ -213,79 +134,96 @@ class TestMCPToolSchemas:
         mock_config: RelaceConfig,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """All tool parameters must have non-empty descriptions in inputSchema."""
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "1")
         monkeypatch.setenv("MCP_SEARCH_RETRIEVAL", "1")
         monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "relace")
         server = build_server(config=mock_config, run_health_check=False)
 
         async with Client(server) as client:
             tools = await client.list_tools()
-            for tool in tools:
-                schema = tool.inputSchema or {}
-                props = schema.get("properties", {})
-                for param_name, param_schema in props.items():
-                    assert isinstance(param_schema, dict), (
-                        f"Tool '{tool.name}' param '{param_name}' schema is not an object"
-                    )
-                    desc = (param_schema.get("description") or "").strip()
-                    assert desc, f"Tool '{tool.name}' param '{param_name}' has no description"
+
+        for tool in tools:
+            schema = tool.inputSchema or {}
+            props = schema.get("properties", {})
+            for param_name, param_schema in props.items():
+                assert isinstance(param_schema, dict), (
+                    f"Tool '{tool.name}' param '{param_name}' schema is not an object"
+                )
+                desc = (param_schema.get("description") or "").strip()
+                assert desc, f"Tool '{tool.name}' param '{param_name}' has no description"
 
 
 class TestMCPToolAnnotations:
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
     async def test_fast_apply_is_destructive(self, mock_config: RelaceConfig) -> None:
-        """fast_apply must be marked as destructive (modifies files)."""
         server = build_server(config=mock_config, run_health_check=False)
 
         async with Client(server) as client:
             tools = await client.list_tools()
-            fast_apply = next((t for t in tools if t.name == "fast_apply"), None)
+            fast_apply = next((tool for tool in tools if tool.name == "fast_apply"), None)
 
-            assert fast_apply is not None
-            annotations = fast_apply.annotations
-            assert annotations is not None
-            assert annotations.destructiveHint is True
-            assert annotations.readOnlyHint is False
+        assert fast_apply is not None
+        annotations = fast_apply.annotations
+        assert annotations is not None
+        assert annotations.destructiveHint is True
+        assert annotations.readOnlyHint is False
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
     async def test_agentic_search_is_readonly(self, mock_config: RelaceConfig) -> None:
-        """agentic_search must be marked as read-only."""
         server = build_server(config=mock_config, run_health_check=False)
 
         async with Client(server) as client:
             tools = await client.list_tools()
-            search = next((t for t in tools if t.name == "agentic_search"), None)
+            search = next((tool for tool in tools if tool.name == "agentic_search"), None)
 
-            assert search is not None
-            annotations = search.annotations
-            assert annotations is not None
-            assert annotations.readOnlyHint is True
-            assert annotations.destructiveHint is False
+        assert search is not None
+        annotations = search.annotations
+        assert annotations is not None
+        assert annotations.readOnlyHint is True
+        assert annotations.destructiveHint is False
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
-    async def test_agentic_retrieval_is_not_readonly(
-        self,
-        mock_config: RelaceConfig,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """agentic_retrieval may schedule background refreshes, so it is not read-only."""
-        monkeypatch.setenv("MCP_SEARCH_RETRIEVAL", "1")
-        monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "relace")
+    async def test_index_status_is_readonly(self, mock_config: RelaceConfig) -> None:
         server = build_server(config=mock_config, run_health_check=False)
 
         async with Client(server) as client:
             tools = await client.list_tools()
-            retrieval = next((t for t in tools if t.name == "agentic_retrieval"), None)
+            status_tool = next((tool for tool in tools if tool.name == STATUS_TOOL), None)
 
-            assert retrieval is not None
-            annotations = retrieval.annotations
-            assert annotations is not None
-            assert annotations.readOnlyHint is False
-            assert annotations.destructiveHint is False
+        assert status_tool is not None
+        annotations = status_tool.annotations
+        assert annotations is not None
+        assert annotations.readOnlyHint is True
+        assert annotations.destructiveHint is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("clean_env")
+    @pytest.mark.parametrize(
+        ("backend", "expected_read_only"),
+        [("relace", True), ("codanna", False), ("chunkhound", False), ("none", True)],
+    )
+    async def test_agentic_retrieval_read_only_depends_on_backend(
+        self,
+        mock_config: RelaceConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        backend: str,
+        expected_read_only: bool,
+    ) -> None:
+        monkeypatch.setenv("MCP_SEARCH_RETRIEVAL", "1")
+        monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", backend)
+        server = build_server(config=mock_config, run_health_check=False)
+
+        async with Client(server) as client:
+            tools = await client.list_tools()
+            retrieval = next((tool for tool in tools if tool.name == "agentic_retrieval"), None)
+
+        assert retrieval is not None
+        annotations = retrieval.annotations
+        assert annotations is not None
+        assert annotations.readOnlyHint is expected_read_only
+        assert annotations.destructiveHint is False
 
 
 class TestMCPToolResponseContract:
@@ -294,7 +232,6 @@ class TestMCPToolResponseContract:
     async def test_fast_apply_returns_structured_response(
         self, mock_config: RelaceConfig, tmp_path: Path
     ) -> None:
-        """fast_apply must return dict with status, message, path keys."""
         server = build_server(config=mock_config, run_health_check=False)
         new_file = tmp_path / "new.py"
 
@@ -304,45 +241,43 @@ class TestMCPToolResponseContract:
                 {"path": str(new_file), "edit_snippet": "print('hello')"},
             )
 
-            content = result.structured_content
-            assert content is not None
-            assert isinstance(content, dict)
-            assert "status" in content
-            assert content["status"] in ("ok", "error")
-            assert "message" in content
-            assert "path" in content
+        content = result.structured_content
+        assert content is not None
+        assert isinstance(content, dict)
+        assert "status" in content
+        assert content["status"] in ("ok", "error")
+        assert "message" in content
+        assert "path" in content
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
     async def test_fast_apply_error_returns_code(
         self, mock_config: RelaceConfig, tmp_path: Path
     ) -> None:
-        """fast_apply error response must include code field."""
         server = build_server(config=mock_config, run_health_check=False)
 
         async with Client(server) as client:
             result = await client.call_tool(
                 "fast_apply",
-                {"path": str(tmp_path / "test.py"), "edit_snippet": ""},  # empty = error
+                {"path": str(tmp_path / "test.py"), "edit_snippet": ""},
             )
 
-            content = result.structured_content
-            assert content is not None
-            assert content["status"] == "error"
-            assert "code" in content
-            assert content["code"] == "INVALID_INPUT"
+        content = result.structured_content
+        assert content is not None
+        assert content["status"] == "error"
+        assert "code" in content
+        assert content["code"] == "INVALID_INPUT"
 
 
 class TestMCPResourceExistence:
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
     async def test_tools_list_resource_absent(self, mock_config: RelaceConfig) -> None:
-        """Legacy tools_list resource should not be registered."""
         server = build_server(config=mock_config, run_health_check=False)
 
         async with Client(server) as client:
             resources = await client.list_resources()
-            resource_uris = [r.uri for r in resources]
+            resource_uris = [resource.uri for resource in resources]
 
             assert not any("tools_list" in str(uri) for uri in resource_uris)
 
@@ -351,37 +286,21 @@ class TestMCPResourceExistence:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
-    async def test_cloud_status_resource_visible_when_enabled(
+    @pytest.mark.parametrize(
+        ("backend", "expected_visible"),
+        [("relace", True), ("codanna", False), ("chunkhound", False), ("none", False)],
+    )
+    async def test_cloud_status_resource_visibility_matches_backend(
         self,
         mock_config: RelaceConfig,
         monkeypatch: pytest.MonkeyPatch,
+        backend: str,
+        expected_visible: bool,
     ) -> None:
-        """Cloud tools must be visible when RELACE_CLOUD_TOOLS=true."""
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "1")
+        monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", backend)
         server = build_server(config=mock_config, run_health_check=False)
-
-        async with Client(server) as client:
-            resources = await client.list_resources()
-            resource_uris = [str(r.uri) for r in resources]
-
-            assert "relace://cloud/status" in resource_uris
-
-    @pytest.mark.asyncio
-    @pytest.mark.usefixtures("clean_env")
-    async def test_cloud_status_resource_hidden_when_disabled(
-        self,
-        mock_config: RelaceConfig,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Cloud tools must be hidden when RELACE_CLOUD_TOOLS=false."""
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "0")
-        server = build_server(config=mock_config, run_health_check=False)
-
-        async with Client(server) as client:
-            resources = await client.list_resources()
-            resource_uris = [str(r.uri) for r in resources]
-
-            assert "relace://cloud/status" not in resource_uris
+        resource_uris = await _list_resource_uris(server)
+        assert ("relace://cloud/status" in resource_uris) is expected_visible
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_env")
@@ -390,12 +309,11 @@ class TestMCPResourceExistence:
         mock_config: RelaceConfig,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Cloud status resource must remain readable when cloud tools are enabled."""
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "1")
+        monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "relace")
         server = build_server(config=mock_config, run_health_check=False)
 
         async with Client(server) as client:
             result = await client.read_resource("relace://cloud/status")
 
-            assert result is not None
-            assert len(result) > 0
+        assert result is not None
+        assert len(result) > 0

--- a/tests/retrieval/test_agentic_retrieval_integration.py
+++ b/tests/retrieval/test_agentic_retrieval_integration.py
@@ -4,6 +4,7 @@ import pytest
 
 from relace_mcp.clients import RelaceRepoClient, SearchLLMClient
 from relace_mcp.config import RelaceConfig
+from relace_mcp.config import settings as settings_mod
 from relace_mcp.repo.freshness import FreshnessStatus
 from relace_mcp.search.retrieval import agentic_retrieval_logic
 
@@ -20,6 +21,12 @@ SEMANTIC_RESULTS = [
     {"filename": "src/main.py", "score": 0.95},
     {"filename": "src/utils.py", "score": 0.80},
 ]
+
+
+@pytest.fixture(autouse=True)
+def _default_retrieval_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings_mod, "RETRIEVAL_BACKEND", "relace")
+    monkeypatch.setattr(settings_mod, "RETRIEVAL_HINT_POLICY", "prefer-stale")
 
 
 @pytest.fixture

--- a/tests/retrieval/test_agentic_retrieval_unit.py
+++ b/tests/retrieval/test_agentic_retrieval_unit.py
@@ -5,9 +5,16 @@ import pytest
 
 from relace_mcp.clients import RelaceRepoClient, SearchLLMClient
 from relace_mcp.config import RelaceConfig
+from relace_mcp.config import settings as settings_mod
 from relace_mcp.repo.freshness import FreshnessStatus
 from relace_mcp.search.prompt_messages import format_hints_list
 from relace_mcp.search.retrieval import _compact_semantic_hints, agentic_retrieval_logic
+
+
+@pytest.fixture(autouse=True)
+def _default_retrieval_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings_mod, "RETRIEVAL_BACKEND", "relace")
+    monkeypatch.setattr(settings_mod, "RETRIEVAL_HINT_POLICY", "prefer-stale")
 
 
 class TestFormatHintsList:
@@ -343,37 +350,6 @@ class TestAgenticRetrievalLogic:
             assert "explanation" in result
             assert result["semantic_hints_used"] == 0
             assert result["hints_index_freshness"] == "missing"
-
-
-class TestResolveAutoBackendNoHealthProbe:
-    """_resolve_auto_backend must not block via health probes."""
-
-    def test_no_check_backend_health_called(self, tmp_path: Path) -> None:
-        from relace_mcp.search.retrieval import _auto_backend_cache, _resolve_auto_backend
-
-        _auto_backend_cache.clear()
-        with (
-            patch("relace_mcp.search.retrieval.shutil.which", return_value=None),
-            patch("relace_mcp.search.retrieval.is_backend_disabled", return_value=False),
-            patch("relace_mcp.repo.backends.check_backend_health") as mock_health,
-        ):
-            result = _resolve_auto_backend(str(tmp_path))
-        assert result == "relace"
-        mock_health.assert_not_called()
-
-    def test_returns_first_available_cli(self, tmp_path: Path) -> None:
-        from relace_mcp.search.retrieval import _auto_backend_cache, _resolve_auto_backend
-
-        _auto_backend_cache.clear()
-        with (
-            patch(
-                "relace_mcp.search.retrieval.shutil.which",
-                side_effect=lambda name: "/usr/bin/" + name if name == "chunkhound" else None,
-            ),
-            patch("relace_mcp.search.retrieval.is_backend_disabled", return_value=False),
-        ):
-            result = _resolve_auto_backend(str(tmp_path))
-        assert result == "chunkhound"
 
 
 class TestChunkHoundIndexFileBug1:

--- a/tests/retrieval/test_agentic_retrieval_unit.py
+++ b/tests/retrieval/test_agentic_retrieval_unit.py
@@ -472,68 +472,29 @@ class TestScheduleBgDedup:
         _bg_index_rerun.pop(key, None)
 
 
-class TestScheduleBgCodannaQueue:
+class TestScheduleBgCodannaRefresh:
     @pytest.mark.asyncio
-    async def test_queues_pending_paths_instead_of_last_write_wins(self) -> None:
+    async def test_running_task_sets_rerun_flag(self) -> None:
         import asyncio
 
         from relace_mcp.repo.backends import schedule_bg_codanna_index
-        from relace_mcp.repo.backends.registry import (
-            _bg_codanna_pending,
-            _bg_index_rerun,
-            _bg_index_tasks,
-        )
+        from relace_mcp.repo.backends.registry import _bg_index_rerun, _bg_index_tasks
 
         base_dir = "/fake/repo/codanna"
         key = (base_dir, "codanna")
         _bg_index_tasks.pop(key, None)
         _bg_index_rerun.pop(key, None)
-        _bg_codanna_pending.pop(key, None)
 
-        first_path = f"{base_dir}/a.py"
-        second_path = f"{base_dir}/b.py"
-        third_path = f"{base_dir}/c.py"
+        async def _never_done() -> None:
+            await asyncio.sleep(10)
 
-        started: list[str] = []
-        unblock = asyncio.Event()
+        running_task = asyncio.create_task(_never_done())
+        _bg_index_tasks[key] = running_task
 
-        async def _fake_index(fp: str, _bd: str) -> None:
-            started.append(fp)
-            if fp == first_path:
-                await unblock.wait()
-
-        with patch(
-            "relace_mcp.repo.backends.codanna_indexing._async_run_codanna_index",
-            side_effect=_fake_index,
-        ):
-            try:
-                schedule_bg_codanna_index(first_path, base_dir)
-                await asyncio.sleep(0)
-                schedule_bg_codanna_index(second_path, base_dir)
-                schedule_bg_codanna_index(third_path, base_dir)
-
-                unblock.set()
-
-                async def _wait_for_all() -> None:
-                    while len(set(started)) < 3:
-                        await asyncio.sleep(0)
-
-                await asyncio.wait_for(_wait_for_all(), timeout=2)
-
-                last_task = _bg_index_tasks.get(key)
-                if last_task is not None:
-                    await last_task
-                    await asyncio.sleep(0)
-            finally:
-                task = _bg_index_tasks.get(key)
-                if task is not None and not task.done():
-                    task.cancel()
-                    try:
-                        await task
-                    except asyncio.CancelledError:
-                        pass
-                _bg_index_tasks.pop(key, None)
-                _bg_index_rerun.pop(key, None)
-                _bg_codanna_pending.pop(key, None)
-
-        assert set(started) == {first_path, second_path, third_path}
+        try:
+            schedule_bg_codanna_index(f"{base_dir}/a.py", base_dir)
+            assert _bg_index_rerun.get(key) is True
+        finally:
+            running_task.cancel()
+            _bg_index_tasks.pop(key, None)
+            _bg_index_rerun.pop(key, None)

--- a/tests/retrieval/test_background_index_monitor_unit.py
+++ b/tests/retrieval/test_background_index_monitor_unit.py
@@ -9,7 +9,7 @@ import relace_mcp.repo.backends.chunkhound as chunkhound_backend
 import relace_mcp.repo.backends.codanna_indexing as codanna_indexing
 import relace_mcp.repo.backends.locking as backend_locking
 import relace_mcp.repo.monitor as bgmon
-from relace_mcp.config import RelaceConfig
+from relace_mcp.config import RelaceConfig, resolve_index_runtime
 from relace_mcp.repo.backends.locking import (
     BackendIndexLease,
     BackendIndexRunResult,
@@ -46,16 +46,24 @@ def _configure_monitor_settings(
     )
 
 
+def _make_monitor(base_dir: str | None) -> BackgroundIndexMonitor:
+    config = RelaceConfig(api_key="rlc-test", base_dir=base_dir)
+    return BackgroundIndexMonitor(
+        config,
+        index_runtime=resolve_index_runtime(base_dir=base_dir),
+    )
+
+
 class TestBackgroundIndexMonitor:
     @pytest.mark.asyncio
     async def test_start_requires_pinned_base_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _configure_monitor_settings(monkeypatch)
 
-        monitor = BackgroundIndexMonitor(RelaceConfig(api_key="rlc-test", base_dir=None))
+        monitor = _make_monitor(None)
         await monitor.start()
 
         summary = monitor.summary()
-        assert summary["enabled"] is False
+        assert summary["state"] == "blocked"
         assert summary["reason"] == "base_dir_not_pinned"
 
     @pytest.mark.asyncio
@@ -65,9 +73,7 @@ class TestBackgroundIndexMonitor:
         _configure_monitor_settings(monkeypatch, retrieval_backend="chunkhound")
 
         with patch("relace_mcp.repo.monitor.shutil.which", return_value="/usr/bin/fake"):
-            monitor = BackgroundIndexMonitor(
-                RelaceConfig(api_key="rlc-test", base_dir=str(tmp_path))
-            )
+            monitor = _make_monitor(str(tmp_path))
             await monitor.start()
             first_task = monitor._task
             await monitor.start()
@@ -78,24 +84,25 @@ class TestBackgroundIndexMonitor:
         assert first_task is second_task
 
     @pytest.mark.asyncio
-    async def test_auto_mode_prefers_codanna_and_runs_only_active_backend(
+    async def test_non_local_backend_stays_disabled(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        _configure_monitor_settings(monkeypatch, retrieval_backend="auto")
-        monitor = BackgroundIndexMonitor(RelaceConfig(api_key="rlc-test", base_dir=str(tmp_path)))
+        _configure_monitor_settings(monkeypatch, retrieval_backend="relace")
+        monitor = _make_monitor(str(tmp_path))
+        await monitor.start()
 
-        with patch(
-            "relace_mcp.repo.monitor.shutil.which",
-            side_effect=lambda name: (
-                f"/usr/bin/{name}" if name in {"codanna", "chunkhound"} else None
-            ),
-        ):
-            backend, reason = monitor._resolve_startup_state()
+        summary = monitor.summary()
+        assert summary["state"] == "blocked"
+        assert summary["reason"] == "backend_not_local"
 
-        assert backend == "codanna"
-        assert reason == "ok"
+    @pytest.mark.asyncio
+    async def test_tick_schedules_only_active_backend(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _configure_monitor_settings(monkeypatch, retrieval_backend="codanna")
+        monitor = _make_monitor(str(tmp_path))
+        monitor._active_backend = "codanna"
 
-        monitor._active_backend = backend
         scheduled_task = asyncio.create_task(
             asyncio.sleep(0, result=BackendIndexRunResult(status="completed"))
         )
@@ -132,7 +139,7 @@ class TestBackgroundIndexMonitor:
             interval_seconds=300,
             initial_delay_seconds=1,
         )
-        monitor = BackgroundIndexMonitor(RelaceConfig(api_key="rlc-test", base_dir=str(tmp_path)))
+        monitor = _make_monitor(str(tmp_path))
 
         delays: list[float] = []
 
@@ -164,7 +171,7 @@ class TestBackgroundIndexMonitor:
             interval_seconds=300,
             initial_delay_seconds=1,
         )
-        monitor = BackgroundIndexMonitor(RelaceConfig(api_key="rlc-test", base_dir=str(tmp_path)))
+        monitor = _make_monitor(str(tmp_path))
 
         delays: list[float] = []
 
@@ -202,7 +209,7 @@ class TestBackgroundIndexMonitor:
         self, tmp_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _configure_monitor_settings(monkeypatch)
-        monitor = BackgroundIndexMonitor(RelaceConfig(api_key="rlc-test", base_dir=str(tmp_path)))
+        monitor = _make_monitor(str(tmp_path))
         monitor._running = True
         monitor._reason = "ok"
 
@@ -211,7 +218,7 @@ class TestBackgroundIndexMonitor:
         monitor._task = finished_task
 
         summary = monitor.summary()
-        assert summary["enabled"] is False
+        assert summary["state"] == "blocked"
 
     @pytest.mark.asyncio
     async def test_tick_registers_monitor_triggered_run_in_bg_registry(
@@ -220,7 +227,7 @@ class TestBackgroundIndexMonitor:
         _configure_monitor_settings(monkeypatch, retrieval_backend="codanna")
         base_dir = str(tmp_path)
         key = (base_dir, "codanna")
-        monitor = BackgroundIndexMonitor(RelaceConfig(api_key="rlc-test", base_dir=base_dir))
+        monitor = _make_monitor(base_dir)
         monitor._active_backend = "codanna"
 
         _bg_index_tasks.pop(key, None)
@@ -289,7 +296,7 @@ class TestBackgroundIndexMonitor:
         self, tmp_path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
         _configure_monitor_settings(monkeypatch, retrieval_backend="chunkhound")
-        monitor = BackgroundIndexMonitor(RelaceConfig(api_key="rlc-test", base_dir=str(tmp_path)))
+        monitor = _make_monitor(str(tmp_path))
         monitor._active_backend = "chunkhound"
 
         caplog.set_level(logging.WARNING)

--- a/tests/retrieval/test_background_index_monitor_unit.py
+++ b/tests/retrieval/test_background_index_monitor_unit.py
@@ -17,7 +17,6 @@ from relace_mcp.repo.backends.locking import (
     try_acquire_backend_index_lock,
 )
 from relace_mcp.repo.backends.registry import (
-    _bg_codanna_pending,
     _bg_index_rerun,
     _bg_index_tasks,
     is_bg_index_running,
@@ -232,7 +231,6 @@ class TestBackgroundIndexMonitor:
 
         _bg_index_tasks.pop(key, None)
         _bg_index_rerun.pop(key, None)
-        _bg_codanna_pending.pop(key, None)
 
         started = asyncio.Event()
         release = asyncio.Event()
@@ -289,7 +287,6 @@ class TestBackgroundIndexMonitor:
         finally:
             _bg_index_tasks.pop(key, None)
             _bg_index_rerun.pop(key, None)
-            _bg_codanna_pending.pop(key, None)
 
     @pytest.mark.asyncio
     async def test_cli_missing_logs_warning_once(
@@ -314,7 +311,7 @@ class TestBackgroundIndexMonitor:
 
 class TestBackendIndexLock:
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("target", ["chunkhound", "codanna_index", "codanna_full"])
+    @pytest.mark.parametrize("target", ["chunkhound", "codanna_full"])
     async def test_lock_error_status_is_normalized(self, tmp_path, target: str) -> None:
         base_dir = str(tmp_path)
         lease = BackendIndexLease(
@@ -331,15 +328,6 @@ class TestBackendIndexLock:
                 return_value=lease,
             ):
                 result = await chunkhound_backend._async_run_chunkhound_index(base_dir)
-        elif target == "codanna_index":
-            with patch(
-                "relace_mcp.repo.backends.codanna_indexing.try_acquire_backend_index_lock",
-                return_value=lease,
-            ):
-                result = await codanna_indexing._async_run_codanna_index(
-                    f"{base_dir}/sample.py",
-                    base_dir,
-                )
         else:
             with patch(
                 "relace_mcp.repo.backends.codanna_indexing.try_acquire_backend_index_lock",

--- a/tests/retrieval/test_chunkhound_unit.py
+++ b/tests/retrieval/test_chunkhound_unit.py
@@ -211,6 +211,19 @@ class TestChunkhoundSearch:
         assert len(results) == 2
 
 
+class TestEnsureChunkhoundIndex:
+    @patch("relace_mcp.repo.backends.chunkhound._mark_chunkhound_index_fresh")
+    @patch("relace_mcp.repo.backends.chunkhound.subprocess.run")
+    def test_marks_index_fresh_after_success(
+        self, mock_run: MagicMock, mock_mark: MagicMock, tmp_path: Path
+    ) -> None:
+        from relace_mcp.repo.backends.chunkhound import _ensure_chunkhound_index
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        _ensure_chunkhound_index(str(tmp_path), {"LANG": "C.UTF-8"})
+        mock_mark.assert_called_once_with(str(tmp_path))
+
+
 class TestChunkhoundHealthCheck:
     @patch("relace_mcp.repo.backends.chunkhound._run_cli_text")
     @patch("relace_mcp.repo.backends.health.shutil.which")

--- a/tests/retrieval/test_codanna_unit.py
+++ b/tests/retrieval/test_codanna_unit.py
@@ -7,6 +7,7 @@ from relace_mcp.repo.backends.codanna import (
     _codanna_health_probe,
     _ensure_codanna_index,
     codanna_auto_reindex,
+    codanna_index_file,
     codanna_search,
 )
 
@@ -69,16 +70,14 @@ class TestCodannaAutoReindex:
         result = codanna_auto_reindex("/tmp/repo")
         assert result == {"action": "skipped", "reason": "index up to date"}
 
-    @patch("relace_mcp.repo.backends.codanna_indexing._write_indexed_head")
     @patch("relace_mcp.repo.backends.codanna_indexing._ensure_codanna_index")
     @patch("relace_mcp.repo.backends.codanna_indexing._read_indexed_head")
     @patch("relace_mcp.repo.backends.codanna_indexing.get_git_head")
-    def test_reindexed_stale_head(self, mock_head, mock_read, mock_ensure, mock_write):
+    def test_reindexed_stale_head(self, mock_head, mock_read, mock_ensure):
         mock_head.return_value = "newhead"
         mock_read.return_value = "oldhead"
         result = codanna_auto_reindex("/tmp/repo")
         mock_ensure.assert_called_once()
-        mock_write.assert_called_once_with("/tmp/repo", "newhead", ".codanna/last_indexed_head")
         assert result == {"action": "reindexed", "old_head": "oldhead", "new_head": "newhead"}
 
     @patch("relace_mcp.repo.backends.codanna_indexing._ensure_codanna_index")
@@ -155,6 +154,21 @@ class TestEnsureCodannaIndex:
         env = {}
         with pytest.raises(RuntimeError, match="codanna CLI not found"):
             _ensure_codanna_index(str(tmp_path), env)
+
+    @patch("relace_mcp.repo.backends.codanna_indexing._mark_codanna_index_fresh")
+    @patch("relace_mcp.repo.backends.codanna_indexing.subprocess.run")
+    def test_marks_index_fresh_after_success(self, mock_run: MagicMock, mock_mark, tmp_path):
+        (tmp_path / ".codanna").mkdir()
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        _ensure_codanna_index(str(tmp_path), {})
+        mock_mark.assert_called_once_with(str(tmp_path))
+
+
+class TestCodannaIndexFile:
+    @patch("relace_mcp.repo.backends.codanna_indexing._ensure_codanna_index")
+    def test_file_edit_triggers_full_refresh(self, mock_ensure: MagicMock, tmp_path) -> None:
+        codanna_index_file("/tmp/repo/src/main.py", str(tmp_path))
+        mock_ensure.assert_called_once()
 
 
 class TestCodannaSearchAutoRetry:

--- a/tests/retrieval/test_index_status_probe_unit.py
+++ b/tests/retrieval/test_index_status_probe_unit.py
@@ -1,9 +1,3 @@
-"""Regression tests for index_status auto-refresh scheduling (P2).
-
-Verifies that index_status always schedules background refresh for stale/missing local
-backends regardless of MCP_RETRIEVAL_BACKEND value.
-"""
-
 from unittest.mock import patch
 
 import pytest
@@ -12,46 +6,25 @@ from relace_mcp.config import RelaceConfig
 from relace_mcp.server import build_server
 
 _TOOLS_MOD = "relace_mcp.tools.mcp_status"
-_REGISTER_MOD = "relace_mcp.tools.register"
+
+
+pytestmark = pytest.mark.usefixtures("clean_env")
 
 
 def _make_config(tmp_path) -> RelaceConfig:
     return RelaceConfig(api_key="rlc-test", base_dir=str(tmp_path))
 
 
-@pytest.mark.parametrize(
-    "retrieval_backend",
-    ["auto", "relace", "none", "codanna", "chunkhound"],
-)
 @pytest.mark.asyncio
-async def test_refresh_scheduled_when_stale_on_any_retrieval_backend(
-    tmp_path, retrieval_backend: str
+@pytest.mark.parametrize("backend", ["relace", "codanna", "chunkhound"])
+async def test_index_status_returns_only_active_backend(
+    tmp_path, monkeypatch, backend: str
 ) -> None:
-    """index_status should schedule background refresh for stale local backends,
-    regardless of MCP_RETRIEVAL_BACKEND.
-    """
+    monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", backend)
     config = _make_config(tmp_path)
 
-    # Create stale local indexes with artifacts present but marker absent.
-    codanna_index_dir = tmp_path / ".codanna" / "index" / "semantic"
-    codanna_index_dir.mkdir(parents=True)
-    (codanna_index_dir / "metadata.json").write_text("{}")
-    chunkhound_dir = tmp_path / ".chunkhound"
-    chunkhound_dir.mkdir()
-    (chunkhound_dir / "db").write_bytes(b"index")
-
-    with (
-        patch(f"{_REGISTER_MOD}._should_register_index_status", return_value=True),
-        patch(f"{_TOOLS_MOD}._settings") as mock_settings,
-        patch(f"{_TOOLS_MOD}.shutil.which", return_value="/usr/local/bin/fake"),
-        patch(f"{_TOOLS_MOD}.schedule_bg_codanna_full_index") as mock_codanna_refresh,
-        patch(f"{_TOOLS_MOD}.schedule_bg_chunkhound_index") as mock_chunkhound_refresh,
-    ):
-        mock_settings.RETRIEVAL_BACKEND = retrieval_backend
-        mock_settings.RELACE_CLOUD_TOOLS = False
-        mock_settings.AGENTIC_RETRIEVAL_ENABLED = False
-
-        server = build_server(config=config)
+    with patch(f"{_TOOLS_MOD}.shutil.which", return_value="/usr/local/bin/fake"):
+        server = build_server(config=config, run_health_check=False)
 
         from fastmcp import Client
 
@@ -60,47 +33,73 @@ async def test_refresh_scheduled_when_stale_on_any_retrieval_backend(
 
     payload = result.structured_content
     assert payload is not None
-    assert payload["background_monitor"]["enabled"] is False
-    assert payload["background_monitor"]["requested"] is False
+    assert payload["active_backend"] == backend
+    assert set(payload) == {
+        "trace_id",
+        "base_dir",
+        "base_dir_source",
+        "active_backend",
+        "backend",
+        "background_monitor",
+    }
+    assert "relace" not in payload
+    assert "codanna" not in payload
+    assert "chunkhound" not in payload
 
-    for backend in ("codanna", "chunkhound"):
-        scheduled = payload[backend]["background_refresh_scheduled"]
-        assert scheduled is True, f"{backend}.background_refresh_scheduled must be True"
+    backend_payload = payload["backend"]
+    assert "freshness" in backend_payload
+    assert "hints_usable" in backend_payload
+    if backend == "relace":
+        assert "sync_state" in backend_payload
+        assert "status" in backend_payload
+    else:
+        assert "cli_path" in backend_payload
+        assert set(backend_payload) == {"cli_path", "freshness", "hints_usable"}
 
-    mock_codanna_refresh.assert_called_once_with(str(tmp_path))
-    mock_chunkhound_refresh.assert_called_once_with(str(tmp_path))
+    background_monitor = payload["background_monitor"]
+    assert "state" in background_monitor
+    assert "reason" in background_monitor
+    assert "interval_seconds" in background_monitor
+    assert "initial_delay_seconds" in background_monitor
 
 
 @pytest.mark.asyncio
-async def test_no_refresh_when_cli_missing(tmp_path) -> None:
-    """When CLI is not found, background_refresh_scheduled must be False."""
+async def test_index_status_local_backend_with_missing_cli_is_read_only(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "codanna")
     config = _make_config(tmp_path)
 
-    with (
-        patch(f"{_REGISTER_MOD}._should_register_index_status", return_value=True),
-        patch(f"{_TOOLS_MOD}._settings") as mock_settings,
-        patch(f"{_TOOLS_MOD}.shutil.which", return_value=None),
-    ):
-        mock_settings.RETRIEVAL_BACKEND = "auto"
-        mock_settings.RELACE_CLOUD_TOOLS = False
-        mock_settings.AGENTIC_RETRIEVAL_ENABLED = False
-
-        server = build_server(config=config)
+    with patch(f"{_TOOLS_MOD}.shutil.which", return_value=None):
+        server = build_server(config=config, run_health_check=False)
 
         from fastmcp import Client
 
         async with Client(server) as client:
             result = await client.call_tool("index_status", {})
+            tools = await client.list_tools()
 
     payload = result.structured_content
     assert payload is not None
-    assert payload["background_monitor"]["enabled"] is False
-    assert payload["background_monitor"]["requested"] is False
-    for backend in ("codanna", "chunkhound"):
-        assert payload[backend]["background_refresh_scheduled"] is False, (
-            f"{backend}: expected False when CLI missing, got "
-            f"{payload[backend]['background_refresh_scheduled']!r}"
-        )
-        assert payload[backend]["hints_usable"] is False, (
-            f"{backend}: hints_usable must be False when CLI missing"
-        )
+    assert payload["active_backend"] == "codanna"
+    assert payload["backend"]["cli_path"] is None
+    assert payload["backend"]["hints_usable"] is False
+
+    status_tool = next(tool for tool in tools if tool.name == "index_status")
+    assert status_tool.annotations is not None
+    assert status_tool.annotations.readOnlyHint is True
+
+
+@pytest.mark.asyncio
+async def test_index_status_hidden_when_backend_is_none(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "none")
+    config = _make_config(tmp_path)
+    server = build_server(config=config, run_health_check=False)
+
+    from fastmcp import Client
+
+    async with Client(server) as client:
+        tools = await client.list_tools()
+        tool_names = {tool.name for tool in tools}
+
+    assert "index_status" not in tool_names

--- a/tests/retrieval/test_index_status_probe_unit.py
+++ b/tests/retrieval/test_index_status_probe_unit.py
@@ -91,6 +91,63 @@ async def test_index_status_local_backend_with_missing_cli_is_read_only(
 
 
 @pytest.mark.asyncio
+async def test_index_status_local_backend_strict_policy_disables_stale_hints(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "codanna")
+    monkeypatch.setenv("MCP_RETRIEVAL_HINT_POLICY", "strict")
+    config = _make_config(tmp_path)
+
+    with (
+        patch(f"{_TOOLS_MOD}.shutil.which", return_value="/usr/local/bin/codanna"),
+        patch(
+            f"{_TOOLS_MOD}.classify_local_index_freshness",
+            return_value=type("Freshness", (), {"freshness": "stale"})(),
+        ),
+        patch(f"{_TOOLS_MOD}.is_backend_disabled", return_value=False),
+    ):
+        server = build_server(config=config, run_health_check=False)
+
+        from fastmcp import Client
+
+        async with Client(server) as client:
+            result = await client.call_tool("index_status", {})
+
+    payload = result.structured_content
+    assert payload is not None
+    assert payload["backend"]["freshness"] == "stale"
+    assert payload["backend"]["hints_usable"] is False
+
+
+@pytest.mark.asyncio
+async def test_index_status_local_backend_disabled_session_disables_hints(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "chunkhound")
+    config = _make_config(tmp_path)
+
+    with (
+        patch(f"{_TOOLS_MOD}.shutil.which", return_value="/usr/local/bin/chunkhound"),
+        patch(
+            f"{_TOOLS_MOD}.classify_local_index_freshness",
+            return_value=type("Freshness", (), {"freshness": "fresh"})(),
+        ),
+        patch(f"{_TOOLS_MOD}.is_backend_disabled", return_value=True),
+    ):
+        server = build_server(config=config, run_health_check=False)
+
+        from fastmcp import Client
+
+        async with Client(server) as client:
+            result = await client.call_tool("index_status", {})
+
+    payload = result.structured_content
+    assert payload is not None
+    assert payload["backend"]["freshness"] == "fresh"
+    assert payload["backend"]["hints_usable"] is False
+
+
+@pytest.mark.asyncio
 async def test_index_status_hidden_when_backend_is_none(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "none")
     config = _make_config(tmp_path)

--- a/tests/search/test_tool_timeouts_unit.py
+++ b/tests/search/test_tool_timeouts_unit.py
@@ -10,7 +10,7 @@ async def test_tool_timeouts(tmp_path, monkeypatch) -> None:
     from relace_mcp.config.settings import reload_settings_from_env
 
     with monkeypatch.context() as m:
-        m.setenv("RELACE_CLOUD_TOOLS", "1")
+        m.setenv("MCP_RETRIEVAL_BACKEND", "relace")
         reload_settings_from_env()
 
         server = build_server(

--- a/tests/server/test_dotenv_registration_integration.py
+++ b/tests/server/test_dotenv_registration_integration.py
@@ -22,7 +22,6 @@ def test_dotenv_path_enables_cloud_and_retrieval_tools(tmp_path: Path) -> None:
     env_file.write_text(
         "\n".join(
             [
-                "RELACE_CLOUD_TOOLS=1",
                 "MCP_SEARCH_RETRIEVAL=1",
                 "MCP_RETRIEVAL_BACKEND=relace",
                 "RELACE_API_KEY=rlc_dummy",
@@ -97,7 +96,10 @@ asyncio.run(_run())
 @pytest.mark.usefixtures("clean_env")
 def test_build_server_loads_dotenv_before_tool_imports(tmp_path: Path) -> None:
     env_file = tmp_path / ".test.env"
-    env_file.write_text("APPLY_SEMANTIC_CHECK=1\n", encoding="utf-8")
+    env_file.write_text(
+        "APPLY_SEMANTIC_CHECK=1\nMCP_RETRIEVAL_BACKEND=none\n",
+        encoding="utf-8",
+    )
 
     repo_root = Path(__file__).resolve().parents[2]
 

--- a/tests/server/test_runtime_integration.py
+++ b/tests/server/test_runtime_integration.py
@@ -216,6 +216,35 @@ class TestMain:
             mock_server.run.assert_called_once_with(show_banner=False)
 
     @pytest.mark.usefixtures("clean_env")
+    def test_main_logs_runtime_from_built_server(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import sys
+
+        from relace_mcp.server import main
+
+        monkeypatch.setenv("RELACE_API_KEY", "rlc-test")
+        monkeypatch.setenv("MCP_BASE_DIR", str(tmp_path))
+        monkeypatch.setattr(sys, "argv", ["relace-mcp"])
+
+        with (
+            patch("relace_mcp.server.build_server") as mock_build,
+            patch("relace_mcp.observability.log_event") as mock_log_event,
+        ):
+            mock_server = MagicMock()
+            mock_server._relace_index_runtime = MagicMock(
+                cloud_tools_enabled=False,
+                active_backend="chunkhound",
+            )
+            mock_build.return_value = mock_server
+
+            main()
+
+        event = mock_log_event.call_args.args[0]
+        assert event["cloud_tools_enabled"] is False
+        assert event["mcp_retrieval_backend"] == "chunkhound"
+
+    @pytest.mark.usefixtures("clean_env")
     def test_main_http_mode(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """HTTP mode calls server.run() with correct arguments via CLI."""
         import sys

--- a/tests/server/test_runtime_integration.py
+++ b/tests/server/test_runtime_integration.py
@@ -16,7 +16,6 @@ def _neutralize_repo_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("RELACE_API_KEY", "")
     monkeypatch.setenv("MCP_BASE_DIR", "")
     monkeypatch.setenv("MCP_LOGGING", "off")
-    monkeypatch.setenv("RELACE_CLOUD_TOOLS", "0")
     monkeypatch.setenv("MCP_SEARCH_RETRIEVAL", "0")
     monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "relace")
 
@@ -42,10 +41,10 @@ class TestBuildServer:
 
     @pytest.mark.usefixtures("clean_env")
     def test_build_succeeds_without_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Server builds without RELACE_API_KEY; error deferred to first tool call."""
+        """Server builds without RELACE_API_KEY when relace backend is disabled."""
         monkeypatch.setenv("RELACE_API_KEY", "")
         monkeypatch.setenv("MCP_BASE_DIR", "")
-        monkeypatch.setenv("RELACE_CLOUD_TOOLS", "0")
+        monkeypatch.setenv("MCP_RETRIEVAL_BACKEND", "none")
         monkeypatch.setenv("MCP_LOGGING", "off")
         server = build_server()
         assert server is not None
@@ -87,10 +86,7 @@ class TestServerToolExecution:
     @pytest.mark.asyncio
     async def test_index_status_success(self, mock_config: RelaceConfig) -> None:
         """Should execute index_status tool successfully."""
-        with (
-            patch("relace_mcp.tools.register._should_register_index_status", return_value=True),
-            patch("relace_mcp.tools.mcp_status.shutil.which", return_value=None),
-        ):
+        with patch("relace_mcp.tools.mcp_status.shutil.which", return_value=None):
             server = build_server(config=mock_config)
 
             async with Client(server) as client:
@@ -101,12 +97,12 @@ class TestServerToolExecution:
 
                 assert result.structured_content is not None
                 payload = result.structured_content
-                for key in ("trace_id", "base_dir", "relace", "codanna", "chunkhound"):
+                for key in ("trace_id", "base_dir", "base_dir_source", "active_backend", "backend"):
                     assert key in payload
-                assert "freshness" in payload["relace"]
-                assert "hints_usable" in payload["relace"]
-                assert "freshness" in payload["codanna"]
-                assert "hints_usable" in payload["codanna"]
+                assert payload["active_backend"] == "relace"
+                assert "freshness" in payload["backend"]
+                assert "hints_usable" in payload["backend"]
+                assert "background_monitor" in payload
 
     @pytest.mark.asyncio
     async def test_fast_apply_creates_new_file(


### PR DESCRIPTION
## Summary
The indexing runtime now exposes exactly one active backend at a time, makes `index_status` a read-only status probe for that active backend, and limits cloud-only tools to the `relace` backend. This reduces backend ambiguity, makes tool discovery more predictable for MCP clients, and aligns retrieval, monitoring, and documentation with a single explicit backend selection model.

## Refactors
- Reworked indexing runtime configuration around a single explicit `MCP_RETRIEVAL_BACKEND` selection.
- Simplified tool registration so `index_status` reports only the active backend and cloud tools are exposed only for `relace`.
- Updated `index_status` schema and descriptions to better guide agents toward freshness checks and `cloud_sync()` when needed.
- Adjusted background monitor behavior to follow the selected local backend instead of multi-backend status aggregation.
- Hardened base directory resolution by ignoring the Windsurf config root during fallback detection.

## Bug Fixes
- Fixed `index_status` typing and schema mismatches so mypy, MCP output validation, and runtime payloads stay aligned.

## Breaking Changes
- `index_status` no longer returns a multi-backend summary; it reports only the active backend.
- `MCP_RETRIEVAL_BACKEND=auto` is no longer supported.
- Legacy cloud-tool compatibility exposure has been removed; cloud tools are available only when `MCP_RETRIEVAL_BACKEND=relace`.

## Migration
- Set `MCP_RETRIEVAL_BACKEND` explicitly to one of `relace`, `codanna`, `chunkhound`, or `none`.
- Update any client logic that expected `index_status` to contain per-backend top-level entries such as `relace`, `codanna`, or `chunkhound`.
- Use `cloud_sync()` only in `relace` mode when `index_status` reports stale cloud state.